### PR TITLE
Test remove node command

### DIFF
--- a/src/ca/mcgill/cs/stg/jetuml/commands/DeleteNodeCommand.java
+++ b/src/ca/mcgill/cs/stg/jetuml/commands/DeleteNodeCommand.java
@@ -46,7 +46,6 @@ public class DeleteNodeCommand extends GraphElementRelatedCommand
 	public void undo() 
 	{
 		aGraph.insertNode((Node)aElement);
-		aGraph.layout();
 	}
 
 	/**
@@ -55,6 +54,5 @@ public class DeleteNodeCommand extends GraphElementRelatedCommand
 	public void execute() 
 	{
 		aGraph.removeNode((Node)aElement);
-		aGraph.layout();
 	}
 }

--- a/test/cs/mcgill/cs/stg/jetuml/commands/TestDeleteNodeCommand.java
+++ b/test/cs/mcgill/cs/stg/jetuml/commands/TestDeleteNodeCommand.java
@@ -1,0 +1,59 @@
+package cs.mcgill.cs.stg.jetuml.commands;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ca.mcgill.cs.stg.jetuml.commands.DeleteNodeCommand;
+import ca.mcgill.cs.stg.jetuml.diagrams.ClassDiagramGraph;
+import ca.mcgill.cs.stg.jetuml.graph.ClassNode;
+import ca.mcgill.cs.stg.jetuml.graph.Graph;
+import ca.mcgill.cs.stg.jetuml.graph.Node;
+
+public class TestDeleteNodeCommand 
+{
+    private Graph aGraph;
+    private Field aNodesToBeRemoved;
+    private Node aNode;
+    private DeleteNodeCommand aDeleteNodeCommand;
+
+    @Before
+    public void setUp() throws Exception 
+    {
+        aGraph = new ClassDiagramGraph();
+        aNode = new ClassNode();
+        aNodesToBeRemoved = aGraph.getClass().getSuperclass().getDeclaredField("aNodesToBeRemoved");
+        aNodesToBeRemoved.setAccessible(true);
+        aDeleteNodeCommand = new DeleteNodeCommand(aGraph, aNode);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testExecute() 
+    {
+        aDeleteNodeCommand.execute();
+        ArrayList<Node> aListNodesToBeRemoved;
+        try 
+        {
+            aListNodesToBeRemoved = (ArrayList<Node>) (aNodesToBeRemoved.get(aGraph));
+            assertTrue(aListNodesToBeRemoved.contains((Node) aNode));
+        } 
+        catch (IllegalArgumentException | IllegalAccessException e1) 
+        {
+            fail();
+        }
+    }
+
+    @Test
+    public void testUndo() 
+    {
+        aDeleteNodeCommand.execute();
+        assertEquals(0, aGraph.getRootNodes().size());
+        aDeleteNodeCommand.undo();
+        assertEquals(1, aGraph.getRootNodes().size());
+    }
+}


### PR DESCRIPTION
Tests for `RemoveNodeCommand`. Also, small fix: There is code duplication between `removeNode()`, `insertNode()` and `layout()`. aNeedsLayout is set to be true twice.