### PR TITLE
#144 Simple fix for self-calls selection issue

### DIFF
--- a/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
+++ b/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
@@ -269,6 +269,23 @@ public class SequenceDiagramGraph extends Graph
 	}
 	
 	/**
+	 * @param pNode The node to obtain the callee for.
+	 * @return The CallNode pointed to by an outgoing edge starting
+	 * at pNode, or null if there are none.
+	 */
+	private CallNode getCallee(Node pNode)
+	{
+		for (Edge edge : aEdges )
+		{
+			if ( edge.getStart() == pNode && edge instanceof CallEdge )
+			{
+				return (CallNode) edge.getEnd();
+			}
+		}
+		return null;
+	}
+	
+	/**
 	 * @param pStart The starting node.
 	 * @param pEnd The end node.
 	 * @return The edge that starts at node pStart and ends at node pEnd, or null if there is no 
@@ -394,6 +411,24 @@ public class SequenceDiagramGraph extends Graph
 	public String getDescription() 
 	{
 		return ResourceBundle.getBundle("ca.mcgill.cs.stg.jetuml.UMLEditorStrings").getString("sequence.name");
+	}
+
+	protected Node deepFindNode( Node pNode, Point2D pPoint )
+	{	
+		if ( pNode instanceof CallNode )
+		{
+			Node child = this.getCallee(pNode);
+			if ( child != null )
+			{
+				Node node = deepFindNode(child, pPoint);
+				if ( node != null )
+				{
+					return node;
+				}
+			}
+		}
+		
+		return super.deepFindNode(pNode, pPoint);
 	}
 }
 

--- a/src/ca/mcgill/cs/stg/jetuml/graph/Graph.java
+++ b/src/ca/mcgill/cs/stg/jetuml/graph/Graph.java
@@ -299,7 +299,7 @@ public abstract class Graph
 		return result;
 	}
 	
-	private Node deepFindNode( Node pNode, Point2D pPoint )
+	protected Node deepFindNode( Node pNode, Point2D pPoint )
 	{
 		Node node = null;
 		if( pNode instanceof ParentNode )


### PR DESCRIPTION
SequenceDiagramGraph reimplements the Graph class' deepFindNode method (which is used to implement selection) so that it gives priority to self-call call nodes when possible