### PR TITLE
#144 Fix for case with multiple callees

### DIFF
--- a/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
+++ b/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
@@ -25,6 +25,7 @@ import java.awt.Graphics2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import ca.mcgill.cs.stg.jetuml.framework.Grid;
@@ -269,20 +270,21 @@ public class SequenceDiagramGraph extends Graph
 	}
 	
 	/**
-	 * @param pNode The node to obtain the callee for.
-	 * @return The CallNode pointed to by an outgoing edge starting
+	 * @param pNode The node to obtain the callees for.
+	 * @return All CallNodes pointed to by an outgoing edge starting
 	 * at pNode, or null if there are none.
 	 */
-	private CallNode getCallee(Node pNode)
+	private List<CallNode> getCallees(Node pNode)
 	{
+		List<CallNode> callees = new ArrayList<CallNode>();
 		for (Edge edge : aEdges )
 		{
 			if ( edge.getStart() == pNode && edge instanceof CallEdge )
 			{
-				return (CallNode) edge.getEnd();
+				callees.add((CallNode) edge.getEnd());
 			}
 		}
-		return null;
+		return callees;
 	}
 	
 	/**
@@ -415,16 +417,19 @@ public class SequenceDiagramGraph extends Graph
 
 	@Override
 	protected Node deepFindNode( Node pNode, Point2D pPoint )
-	{	
+	{		
 		if ( pNode instanceof CallNode )
 		{
-			Node child = getCallee(pNode);
-			if ( child != null )
+			for (Node child : getCallees(pNode))
 			{
-				Node node = deepFindNode(child, pPoint);
-				if ( node != null )
+			
+				if ( child != null )
 				{
-					return node;
+					Node node = deepFindNode(child, pPoint);
+					if ( node != null )
+					{
+						return node;
+					}
 				}
 			}
 		}

--- a/test/ca/mcgill/cs/stg/jetuml/diagrams/TestSequenceDiagramGraph.java
+++ b/test/ca/mcgill/cs/stg/jetuml/diagrams/TestSequenceDiagramGraph.java
@@ -38,6 +38,7 @@ import ca.mcgill.cs.stg.jetuml.graph.ImplicitParameterNode;
 
 /**
  * @author Martin P. Robillard
+ * @author Gabriel Cormier-Affleck (testDeepFindNodeTwoChildren)
  */
 public class TestSequenceDiagramGraph
 {
@@ -95,4 +96,61 @@ public class TestSequenceDiagramGraph
 		// Point inside both the caller and the callee
 		assertTrue(aGraph.deepFindNode(node, new Point2D.Double(64, 110)) == callee);
 	 }
+
+	@Test
+	public void testDeepFindNodeTwoChildren()
+	{
+		/*
+		 * Here we have two implicit parameters (param and param2).
+		 * The first implicit parameter has a call edge (callEdge) from 
+		 * its own call node (node) to call node on the second implicit 
+		 * parameter (node2), and a call edge (callEdge2) from its own call
+		 * node (node) to a new call node also on itself, that is, a self-call
+		 * (node3).
+		 * 
+		 * This exact setup is illustrated at http://cs.mcgill.ca/~gcormi5/test1.jpg
+		 */
+	
+		ImplicitParameterNode param = new ImplicitParameterNode();
+		aGraph.addNode(param, new Point2D.Double(118, 0));
+		aGraph.layout(aGraphics, aGrid);
+
+		CallNode node = new CallNode();
+		aGraph.addNode(node, new Point2D.Double(152, 70));
+		aGraph.layout(aGraphics, aGrid);		
+
+		ImplicitParameterNode param2 = new ImplicitParameterNode();
+		aGraph.addNode(param2, new Point2D.Double(347, 0));
+		aGraph.layout(aGraphics, aGrid);
+
+		CallNode node2 = new CallNode();
+		aGraph.addNode(node2, new Point2D.Double(382, 80));
+		aGraph.layout(aGraphics, aGrid);
+
+		Edge callEdge = new CallEdge();
+		aGraph.insertEdge(callEdge);
+		callEdge.connect(node, node2);
+		aGraph.layout(aGraphics, aGrid);
+
+		CallNode node3 = new CallNode();
+		aGraph.addNode(node3, new Point2D.Double(160, 125));
+		aGraph.layout(aGraphics, aGrid);		
+
+		Edge callEdge2 = new CallEdge();
+		aGraph.insertEdge(callEdge2);
+		callEdge2.connect(node, node3);
+		aGraph.layout(aGraphics, aGrid);
+
+		// Point outside the bounds
+		assertNull(aGraph.deepFindNode(node, new Point2D.Double(171, 71)));
+		
+		// Point inside the bounds of the caller but not the self-call callee
+		assertTrue(aGraph.deepFindNode(node, new Point2D.Double(157, 96)) == node);
+		
+		// Point inside the bounds of the call node on the second implicit parameter
+		assertTrue(aGraph.deepFindNode(node, new Point2D.Double(386, 96)) == node2);
+
+		// Point inside both caller and self-call callee
+		assertTrue(aGraph.deepFindNode(node, new Point2D.Double(161, 139)) == node3);
+	}
 }


### PR DESCRIPTION
The earlier patch worked if the self-call was the only callee. This additionally fixes a more subtle case when a callNode has multiple callees, one of which is a self-call.

As illustrated here: http://i.imgur.com/5D0XZkt.png
