### PR TITLE
Use Node instead of CallNode in getCallees

### DIFF
--- a/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
+++ b/src/ca/mcgill/cs/stg/jetuml/diagrams/SequenceDiagramGraph.java
@@ -271,17 +271,17 @@ public class SequenceDiagramGraph extends Graph
 	
 	/**
 	 * @param pNode The node to obtain the callees for.
-	 * @return All CallNodes pointed to by an outgoing edge starting
+	 * @return All Nodes pointed to by an outgoing edge starting
 	 * at pNode, or null if there are none.
 	 */
-	private List<CallNode> getCallees(Node pNode)
+	private List<Node> getCallees(Node pNode)
 	{
-		List<CallNode> callees = new ArrayList<CallNode>();
+		List<Node> callees = new ArrayList<Node>();
 		for (Edge edge : aEdges )
 		{
 			if ( edge.getStart() == pNode && edge instanceof CallEdge )
 			{
-				callees.add((CallNode) edge.getEnd());
+				callees.add(edge.getEnd());
 			}
 		}
 		return callees;


### PR DESCRIPTION
CallEdges may go from CallNodes to ImplicitParameterNodes, not just CallNodes, so use Node which covers both. Otherwise the selection tool crashes trying to cast a ImplicitParameterNode to CallNode when working with diagrams with a create edge.

#144 is still fixed either way, this is a distinct regression. Sorry for the mistake in the fix, everything is thoroughly tested now and this will be the last pull regarding this