### PR TITLE
#224 Fix some minor bugs relating to state diagram edges

### DIFF
--- a/src/ca/mcgill/cs/jetuml/views/edges/StateTransitionEdgeView.java
+++ b/src/ca/mcgill/cs/jetuml/views/edges/StateTransitionEdgeView.java
@@ -183,7 +183,7 @@ public class StateTransitionEdgeView extends AbstractEdgeView
 		// Additional gap to make sure the labels don't overlap
 		if( edge().getGraph() != null && getPosition() > 1 )
 		{
-			double delta = Math.abs(Math.atan2((line.getX2()-line.getX1()),(line.getY2()-line.getY1())));
+			double delta = Math.abs(Math.atan2(line.getX2()-line.getX1(),line.getY2()-line.getY1()));
 			delta = dimension.getHeight() - delta*RADIANS_TO_PIXELS;
 			if( line.getX1() <= line.getX2() )
 			{

--- a/src/ca/mcgill/cs/jetuml/views/edges/StateTransitionEdgeView.java
+++ b/src/ca/mcgill/cs/jetuml/views/edges/StateTransitionEdgeView.java
@@ -183,7 +183,7 @@ public class StateTransitionEdgeView extends AbstractEdgeView
 		// Additional gap to make sure the labels don't overlap
 		if( edge().getGraph() != null && getPosition() > 1 )
 		{
-			double delta = Math.abs(Math.atan((line.getX2()-line.getX1())/(line.getY2()-line.getY1())));
+			double delta = Math.abs(Math.atan2((line.getX2()-line.getX1()),(line.getY2()-line.getY1())));
 			delta = dimension.getHeight() - delta*RADIANS_TO_PIXELS;
 			if( line.getX1() <= line.getX2() )
 			{
@@ -285,7 +285,7 @@ public class StateTransitionEdgeView extends AbstractEdgeView
 			{
 				lReturn++;
 			}
-			if( edge == this )
+			if( edge == edge() )
 			{
 				return lReturn;
 			}


### PR DESCRIPTION
The first thing changed is to use atan2 instead of atan which avoids division by zero problems as exposed by the unit test.

The second thing changed is to fix a minor mistake in the getPosition() method of StateTransitionEdgeView.java which was preventing multiple state transition edges between two nodes from rendering correctly in the editor GUI. Without that fix if you have multiple state transition edges they will render as the same one in the GUI

Hopefully this helps