### PR TITLE
Minor improvement to class diagram tests

### DIFF
--- a/test/ca/mcgill/cs/jetuml/diagram/TestUsageScenariosClassDiagram.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestUsageScenariosClassDiagram.java
@@ -197,7 +197,7 @@ public class TestUsageScenariosClassDiagram extends AbstractTestUsageScenarios
 		// if begin with a NoteNode, the end point can be anywhere
 		addEdge(noteEdge2, new Point(138, 140), new Point(9,9));
 		assertEquals(noteEdge2.getStart(), aNoteNode);
-		assertEquals(noteEdge2.getEnd().getClass(), new PointNode().getClass());
+		assertEquals(noteEdge2.getEnd().getClass(), PointNode.class);
 		assertEquals(2, numberOfEdges());
 	}
 	


### PR DESCRIPTION
A single one line improvement; sorry if it's too short of a PR. In short I just replaced getting the class of an object through a new instance with a static call to the class's class object.