### PR TITLE
#142 Reorder the selected elements to be drawn on top

### DIFF
--- a/src/ca/mcgill/cs/jetuml/diagram/Diagram.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/Diagram.java
@@ -131,6 +131,16 @@ public abstract class Diagram implements DiagramData
 	}
 
 	/**
+	 * @param pNode
+	 * @return True if pNode is a root node of the Diagram
+	 */
+	public boolean rootNodesContain(Node pNode) 
+	{
+		assert pNode !=null;
+		return aRootNodes.contains(pNode);
+	}
+	
+	/**
 	 * Gets the node types of a particular diagram type.
 	 * @return An array of node prototypes
 	 */   

--- a/src/ca/mcgill/cs/jetuml/diagram/Diagram.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/Diagram.java
@@ -23,6 +23,7 @@ package ca.mcgill.cs.jetuml.diagram;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import ca.mcgill.cs.jetuml.diagram.nodes.ChildNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ParentNode;
 
 /**
@@ -134,9 +135,9 @@ public abstract class Diagram implements DiagramData
 	 * @param pNode
 	 * @return True if pNode is a root node of the Diagram
 	 */
-	public boolean rootNodesContain(Node pNode) 
+	public boolean containsAsRoot(Node pNode) 
 	{
-		assert pNode !=null;
+		assert pNode != null;
 		return aRootNodes.contains(pNode);
 	}
 	
@@ -282,5 +283,35 @@ public abstract class Diagram implements DiagramData
 	{
 		assert pEdge != null && aEdges.contains(pEdge);
 		aEdges.remove(pEdge);
+	}
+	
+	/**
+	 * Recursively reorder the node to be on top of its parent's children.
+	 * If the node is not a child node or the node does not have a parent, check if 
+	 * the node is a root node of the diagram and place it on top.
+	 * 
+	 * @param pNode The node to be placed on top
+	 * @pre pNode != null
+	 */
+	public void placeOnTop(Node pNode)
+	{
+		assert pNode != null;
+		ParentNode parent = null;
+		if (pNode instanceof ChildNode)
+		{
+			parent = ((ChildNode)pNode).getParent();
+		}
+		if (parent != null) 
+		{
+			// Move the child node to the top of all other children
+			parent.moveChildToLastPlace((ChildNode)pNode);
+			// Recursively reorder the node's parent
+			placeOnTop(parent);
+		}
+		else if(containsAsRoot(pNode))
+		{
+			removeRootNode(pNode);
+			addRootNode(pNode);
+		}
 	}
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/nodes/ParentNode.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/nodes/ParentNode.java
@@ -59,4 +59,16 @@ public interface ParentNode extends Node
 	 * @param pNode The child to remove.
 	 */
 	void removeChild(ChildNode pNode);
+	
+	/**
+	 * Move the child node to the last position in the list of children
+	 * @param pNode The child to move
+	 * @pre pNode != null
+	 */
+	default void moveChildToLastPlace(ChildNode pNode)
+	{
+		assert pNode != null;
+		removeChild(pNode);
+		addChild(pNode);
+	}
 }

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -307,6 +307,12 @@ public class DiagramCanvasController
 				// The test is necessary to ensure we don't undo multiple selections
 				aSelectionModel.set(element.get());
 			}
+			
+			// Reorder the selected nodes to ensure that they appear on the top
+			for(Node pSelected: aSelectionModel.getSelectedNodes()) 
+			{
+				reorderSelectedNode(pSelected);
+			}
 			aDragMode = DragMode.DRAG_MOVE;
 			aMoveTracker.startTrackingMove(aSelectionModel);
 		}
@@ -320,6 +326,34 @@ public class DiagramCanvasController
 		}
 	}
 
+	/* Recursively reorder the node to be on top of its parent's all children. 
+	 * If the node is not a child node or it does not have a parent, check if 
+	 * the node is a root node of the diagram and reorder it to be on the top 
+	 * of other root nodes.
+	 */
+	private void reorderSelectedNode(Node pNode) 
+	{
+		assert pNode != null;
+		ParentNode parent = null;
+		if (pNode instanceof ChildNode)
+		{
+			parent = ((ChildNode)pNode).getParent();
+		}
+		if(parent != null) 
+		{
+			// Move the child node to the top of all other children  
+			parent.removeChild((ChildNode)pNode);
+			parent.addChild((ChildNode)pNode);
+			// Recursively reorder the node's parent
+			reorderSelectedNode(parent);
+		}
+		else if(aCanvas.getDiagram().rootNodesContain(pNode))
+		{
+			aCanvas.getDiagram().removeRootNode(pNode);
+			aCanvas.getDiagram().addRootNode(pNode);
+		}
+	}
+	
 	private void handleSingleClick(MouseEvent pEvent)
 	{
 		Optional<DiagramElement> tool = getTool(pEvent);

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -311,7 +311,7 @@ public class DiagramCanvasController
 			// Reorder the selected nodes to ensure that they appear on the top
 			for(Node pSelected: aSelectionModel.getSelectedNodes()) 
 			{
-				reorderSelectedNode(pSelected);
+				aCanvas.getDiagram().placeOnTop(pSelected);
 			}
 			aDragMode = DragMode.DRAG_MOVE;
 			aMoveTracker.startTrackingMove(aSelectionModel);
@@ -323,34 +323,6 @@ public class DiagramCanvasController
 				aSelectionModel.clearSelection();
 			}
 			aDragMode = DragMode.DRAG_LASSO;
-		}
-	}
-
-	/* Recursively reorder the node to be on top of its parent's all children. 
-	 * If the node is not a child node or it does not have a parent, check if 
-	 * the node is a root node of the diagram and reorder it to be on the top 
-	 * of other root nodes.
-	 */
-	private void reorderSelectedNode(Node pNode) 
-	{
-		assert pNode != null;
-		ParentNode parent = null;
-		if (pNode instanceof ChildNode)
-		{
-			parent = ((ChildNode)pNode).getParent();
-		}
-		if(parent != null) 
-		{
-			// Move the child node to the top of all other children  
-			parent.removeChild((ChildNode)pNode);
-			parent.addChild((ChildNode)pNode);
-			// Recursively reorder the node's parent
-			reorderSelectedNode(parent);
-		}
-		else if(aCanvas.getDiagram().rootNodesContain(pNode))
-		{
-			aCanvas.getDiagram().removeRootNode(pNode);
-			aCanvas.getDiagram().addRootNode(pNode);
 		}
 	}
 	

--- a/test/ca/mcgill/cs/jetuml/diagram/TestDiagram.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestDiagram.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * JetUML - A desktop application for fast UML diagramming.
+ *
+ * Copyright (C) 2016, 2019 by the contributors of the JetUML project.
+ *
+ * See: https://github.com/prmr/JetUML
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+package ca.mcgill.cs.jetuml.diagram;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import ca.mcgill.cs.jetuml.JavaFXLoader;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.nodes.AbstractNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ChildNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.PackageNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ParentNode;
+
+import java.util.Iterator;
+
+public class TestDiagram 
+{
+	private Diagram aDiagram;
+	private Node aNode1;
+	private ChildNode aNode2;
+	private ChildNode aNode3;
+	private ParentNode aNode4;
+	
+	static class StubDiagram extends Diagram
+	{
+		@Override
+		public Node[] getNodePrototypes() 
+		{
+			return null;
+		}
+		
+		@Override
+		public String getFileExtension() 
+		{
+			return null;
+		}
+		
+		@Override
+		public Edge[] getEdgePrototypes() 
+		{
+			return null;
+		}
+		
+		@Override
+		public String getDescription() 
+		{
+			return "Stub Diagram";
+		}
+	}
+	
+	static class StubNode extends AbstractNode{ }
+	
+	@BeforeAll
+	public static void setupClass()
+	{
+		JavaFXLoader.load();
+	}
+	
+	@BeforeEach
+	public void setup()
+	{
+		aDiagram = new StubDiagram();
+		aNode1 = new StubNode();
+		aNode2 = new PackageNode();
+		aNode3 = new ClassNode();
+		aNode4 = new PackageNode();
+	}
+	
+	@Test
+	public void testContainsAsRoot_RootNode()
+	{
+		aDiagram.addRootNode(aNode1);
+		assertTrue(aDiagram.containsAsRoot(aNode1));
+	}
+	
+	@Test
+	public void testContainsAsRoot_NonRootNode()
+	{
+		assertFalse(aDiagram.containsAsRoot(aNode1));
+	}
+	
+	@Test
+	public void testContainsAsRoot_NullNode()
+	{
+		assertThrows(AssertionError.class, ()->aDiagram.containsAsRoot(null));
+	}
+	
+	@Test
+	public void testPlaceOnTop_NonRootNode()
+	{
+		aDiagram.addRootNode(aNode2);
+		aDiagram.placeOnTop(aNode1);
+		Iterator<Node> pIterator = aDiagram.rootNodes().iterator();
+		assertSame(pIterator.next(), aNode2);
+		assertFalse(pIterator.hasNext());
+	}
+	
+	@Test
+	public void testPlaceOnTop_ChildNodeWithParent()
+	{
+		aNode4.addChild(aNode2);
+		aNode2.setParent(aNode4);
+		aNode4.addChild(aNode3);
+		aNode3.setParent(aNode4);
+		
+		aDiagram.addRootNode(aNode4);
+		aDiagram.addRootNode(aNode1);
+		aDiagram.placeOnTop(aNode2);
+		
+		Iterator<Node> pIterator = aDiagram.rootNodes().iterator();
+		assertSame(pIterator.next(), aNode1);
+		assertSame(pIterator.next(), aNode4);
+		// Ensure that the moved child node is now on top of all children
+		assertSame(aNode4.getChildren().get(1), aNode2);
+	}
+	
+	@Test
+	public void testPlaceOnTop_NullNode()
+	{
+		assertThrows(AssertionError.class, ()->aDiagram.placeOnTop(null));
+	}
+}

--- a/test/ca/mcgill/cs/jetuml/diagram/TestDiagram.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestDiagram.java
@@ -23,7 +23,6 @@ package ca.mcgill.cs.jetuml.diagram;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
@@ -107,12 +106,6 @@ public class TestDiagram
 	}
 	
 	@Test
-	public void testContainsAsRoot_NullNode()
-	{
-		assertThrows(AssertionError.class, ()->aDiagram.containsAsRoot(null));
-	}
-	
-	@Test
 	public void testPlaceOnTop_NonRootNode()
 	{
 		aDiagram.addRootNode(aNode2);
@@ -139,11 +132,5 @@ public class TestDiagram
 		assertSame(pIterator.next(), aNode4);
 		// Ensure that the moved child node is now on top of all children
 		assertSame(aNode4.getChildren().get(1), aNode2);
-	}
-	
-	@Test
-	public void testPlaceOnTop_NullNode()
-	{
-		assertThrows(AssertionError.class, ()->aDiagram.placeOnTop(null));
 	}
 }


### PR DESCRIPTION
**Summary of Changes:**

Add a _rootNodesContain(Node): boolean_ method in the Diagram class so that one could easily check if a node is a root node of the Diagram. Add the reordering algorithm/method in the DiagramCanvasController class by iterating through the selected elements and reorder each element recursively.

**Achieved Performance:**
1. Whichever root node selected would be on top of all other root nodes of the Diagram.

2. Nested node: a. The selected child node would be on top of all the other children of the same parent node. b. The parent of the selected child node would be on top of all the other nodes within the same depth level as it is. If the parent is also a child node, do this recursively (until reaching the root nodes of the Diagram/ the node itself does not have a parent).

**Design Concerns:**

1. The _rootNodesContain(Node): boolean_ method could be omitted and one could iterate the root nodes of the Diagram to check if the given node is a root or not. Since the diagram is only responsible for handling its root nodes and leaves the children nodes to their parent node to handle, I feel that such a checking method might be useful if we want to add more complex operations dealing with the parent nodes (e.g. package nodes).

2. I separate the reordering method _reorderSelectedNode(Node): void_ from the _handleSelection_ method so that it could be recursively called. I choose the recursive design instead of iterative to have better readability of the code.

3. The reordering is dealing with nodes only. The position order of the edge during the movement/selection does not really impede the visual display. Could look for future improvements.

