### PR TITLE
#327 Modify the node bounds when moving parent node through child node

### DIFF
--- a/src/ca/mcgill/cs/jetuml/geom/Rectangle.java
+++ b/src/ca/mcgill/cs/jetuml/geom/Rectangle.java
@@ -163,7 +163,7 @@ public class Rectangle
 	
 	/**
 	 * @param pRectangle The rectangle to include.
-	 * @return A new rectangle that is this rectangle enlarged to include pPoint.
+	 * @return A new rectangle that is this rectangle enlarged to include pRectangle.
 	 * @pre pRectangle != null
 	 */ 
 	public Rectangle add(Rectangle pRectangle)

--- a/src/ca/mcgill/cs/jetuml/gui/SelectionModel.java
+++ b/src/ca/mcgill/cs/jetuml/gui/SelectionModel.java
@@ -78,7 +78,7 @@ public class SelectionModel implements Iterable<DiagramElement>
 		pDiagramData.edges().forEach(this::internalAddToSelection);
 		aObserver.selectionModelChanged();
 	}
-	
+
 	/**
 	 * @return A rectangle that represents the bounding
 	 * box of the entire selection.
@@ -90,9 +90,22 @@ public class SelectionModel implements Iterable<DiagramElement>
 		Rectangle bounds = ViewerUtilities.getBounds(lastSelected.get());
 		for(DiagramElement selected : aSelected )
 		{
-			bounds = bounds.add(ViewerUtilities.getBounds(selected));
+			bounds = addBounds(bounds, selected);
 		}
 		return bounds;
+	}
+	
+	// Recursively enlarge the current rectangle to include the selected DiagramElements
+	private Rectangle addBounds(Rectangle pBounds,DiagramElement pSelected)
+	{
+		if( pSelected instanceof ChildNode && ((ChildNode) pSelected).getParent()!=null )
+		{
+			return addBounds(pBounds, ((ChildNode) pSelected).getParent());
+		}
+		else
+		{
+			return pBounds.add(ViewerUtilities.getBounds(pSelected));
+		}
 	}
 	
 	/**


### PR DESCRIPTION

**Summary of Changes**

- Add a private helper method to recursively modify the bounds of the selected nodes in the `SelectionModel` class.

**Achieved Performance**

- Moving parent node through child node would not go beyond the canvas.
