### PR TITLE
#269 Create Constructor Call Support in Sequence Diagram

### DIFF
--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -227,6 +227,10 @@ public final class ControlFlow
 				calls.contains(pCallee);
 	}
 	
+	/**
+	 * @param pNode The node to check.
+	 * @return True if pNode is a CallNode and is at the end of a ConstructorEdge.
+	 */
 	public boolean isInConstructorCall(Node pNode)
 	{
 		assert pNode != null;

--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 
@@ -66,7 +67,7 @@ public final class ControlFlow
 		List<Node> callees = new ArrayList<>();
 		for(Edge edge : aDiagram.edges() )
 		{
-			if ( edge.getStart() == pNode && edge.getClass() == CallEdge.class )
+			if ( edge.getStart() == pNode && edge instanceof CallEdge)
 			{
 				callees.add(edge.getEnd());
 			}
@@ -85,7 +86,7 @@ public final class ControlFlow
 		ArrayList<CallEdge> result = new ArrayList<>();
 		for( Edge edge : aDiagram.edges() )
 		{
-			if( edge.getClass() == CallEdge.class && edge.getStart() == pCaller )
+			if( edge instanceof CallEdge && edge.getStart() == pCaller )
 			{
 				result.add((CallEdge)edge);
 			}
@@ -106,7 +107,7 @@ public final class ControlFlow
 		assert pNode != null && aDiagram.contains(pNode);
 		for( Edge edge : aDiagram.edges() )
 		{
-			if( edge.getEnd() == pNode  && edge.getClass() == CallEdge.class )
+			if( edge.getEnd() == pNode  && edge instanceof CallEdge )
 			{
 				return Optional.of((CallNode) edge.getStart());
 			}
@@ -225,5 +226,17 @@ public final class ControlFlow
 				calls.size() == 1 &&
 				calls.contains(pCallee);
 	}
-
+	
+	public boolean isInConstructorCall(Node pNode)
+	{
+		assert pNode != null;
+		for(Edge edge : aDiagram.edges())
+		{
+			if ( pNode.getClass() == CallNode.class && edge.getEnd() == pNode && edge.getClass() == ConstructorEdge.class )
+			{
+				return true;
+			}
+		}
+		return false;	
+	}
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -40,12 +40,14 @@ import ca.mcgill.cs.jetuml.diagram.builder.constraints.ConstraintSet;
 import ca.mcgill.cs.jetuml.diagram.builder.constraints.EdgeConstraints;
 import ca.mcgill.cs.jetuml.diagram.edges.NoteEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.NoteNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.PointNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.nodes.ImplicitParameterNodeViewer;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import ca.mcgill.cs.jetuml.views.DiagramViewer;
 
@@ -155,6 +157,19 @@ public abstract class DiagramBuilder
 		);
 		constraints.merge(getAdditionalEdgeConstraints(pEdge, startNode.get(), endNode.get(), pStart, pEnd));
 		return constraints.satisfied();
+	}
+	
+	/**
+	 * Returns whether a constructor call could be created.
+	 * @param pEnd The node to check.
+	 * @return True if the end node of the edge is an ImplicitParameterNode with no child nodes.
+	 */
+	public boolean canCreateConstructorCall(Point pEnd)
+	{
+		DiagramViewer viewer = viewerFor(aDiagram);
+		Node endNode = viewer.findNode(aDiagram, pEnd).get();
+		return endNode instanceof ImplicitParameterNode && new ImplicitParameterNodeViewer().getTopRectangle(endNode).contains(pEnd)
+				&& ((ImplicitParameterNode)endNode).getChildren().size()==0;
 	}
 	
 	/**

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -74,11 +74,15 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 			);
 		if( !canCreateConstructorCall(pStart, pEnd, pEndPoint) )
 		{
+			// The edge could not land on the top rectangle of ImplicitParameterNode if cannot create constructor call
 			constraintSet.merge( new ConstraintSet(SequenceDiagramEdgeConstraints.callEdgeEnd(pEdge, pEnd, pEndPoint)) );
 		}
 		return constraintSet;
 	}
 	
+	/*
+	 * Returns true if the end node of the edge is an ImplicitParameterNode with no child nodes.
+	 */
 	private boolean canCreateConstructorCall(Node pStartNode, Node pEndNode, Point pEndPoint)
 	{
 		return pEndNode instanceof ImplicitParameterNode && IMPLICIT_PARAMETER_NODE_VIEWER.getTopRectangle(pEndNode).contains(pEndPoint)
@@ -235,8 +239,8 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 		{
 			pEdge = new ConstructorEdge();
 		}
-		final Edge edge = pEdge;
 		pEdge.connect(start, end, aDiagram);
+		final Edge edge = pEdge;
 		pOperation.add(new SimpleOperation(()-> aDiagram.addEdge(insertionIndex, edge),
 				()-> aDiagram.removeEdge(edge)));
 	}

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -34,7 +34,6 @@ import ca.mcgill.cs.jetuml.diagram.builder.constraints.ConstraintSet;
 import ca.mcgill.cs.jetuml.diagram.builder.constraints.EdgeConstraints;
 import ca.mcgill.cs.jetuml.diagram.builder.constraints.SequenceDiagramEdgeConstraints;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
-import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ReturnEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
@@ -72,21 +71,12 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 				SequenceDiagramEdgeConstraints.returnEdge(pEdge, pStart, pEnd, aDiagram),
 				SequenceDiagramEdgeConstraints.singleEntryPoint(pEdge, pStart, aDiagram)
 			);
-		if( !canCreateConstructorCall(pStart, pEnd, pEndPoint) )
+		if( !canCreateConstructorCall(pEndPoint) )
 		{
 			// The edge could not land on the top rectangle of ImplicitParameterNode if cannot create constructor call
 			constraintSet.merge( new ConstraintSet(SequenceDiagramEdgeConstraints.callEdgeEnd(pEdge, pEnd, pEndPoint)) );
 		}
 		return constraintSet;
-	}
-	
-	/*
-	 * Returns true if the end node of the edge is an ImplicitParameterNode with no child nodes.
-	 */
-	private boolean canCreateConstructorCall(Node pStartNode, Node pEndNode, Point pEndPoint)
-	{
-		return pEndNode instanceof ImplicitParameterNode && IMPLICIT_PARAMETER_NODE_VIEWER.getTopRectangle(pEndNode).contains(pEndPoint)
-				&& ((ImplicitParameterNode)pEndNode).getChildren().size()==0;
 	}
 	
 	private void addEdgeEndIfItHasNoCallees(List<DiagramElement> pElements, DiagramElement pTarget)
@@ -190,7 +180,7 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 	protected void completeEdgeAdditionOperation( CompoundOperation pOperation, Edge pEdge, Node pStartNode, Node pEndNode,
 			Point pStartPoint, Point pEndPoint)
 	{
-		if( pEdge.getClass() != CallEdge.class )
+		if( !(pEdge instanceof CallEdge) )
 		{
 			super.completeEdgeAdditionOperation(pOperation, pEdge, pStartNode, pEndNode, pStartPoint, pEndPoint);
 			return;
@@ -235,14 +225,9 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 		}
 		));
 		int insertionIndex = computeInsertionIndex(start, pStartPoint.getY());
-		if(canCreateConstructorCall(pStartNode, pEndNode, pEndPoint))
-		{
-			pEdge = new ConstructorEdge();
-		}
 		pEdge.connect(start, end, aDiagram);
-		final Edge edge = pEdge;
-		pOperation.add(new SimpleOperation(()-> aDiagram.addEdge(insertionIndex, edge),
-				()-> aDiagram.removeEdge(edge)));
+		pOperation.add(new SimpleOperation(()-> aDiagram.addEdge(insertionIndex, pEdge),
+				()-> aDiagram.removeEdge(pEdge)));
 	}
 	
 	private int computeInsertionIndex( Node pCaller, int pY)

--- a/src/ca/mcgill/cs/jetuml/diagram/edges/CallEdge.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/edges/CallEdge.java
@@ -26,7 +26,7 @@ import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 /**
  * An edge that joins two call nodes.
  */
-public final class CallEdge extends SingleLabelEdge
+public class CallEdge extends SingleLabelEdge
 {
 	private boolean aSignal;
 	
@@ -73,5 +73,3 @@ public final class CallEdge extends SingleLabelEdge
 				getEnd().getParent() == getStart().getParent();
 	}
 }
-
-

--- a/src/ca/mcgill/cs/jetuml/diagram/edges/ConstructorEdge.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/edges/ConstructorEdge.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * JetUML - A desktop application for fast UML diagramming.
+ *
+ * Copyright (C) 2016, 2019 by the contributors of the JetUML project.
+ *
+ * See: https://github.com/prmr/JetUML
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+
+package ca.mcgill.cs.jetuml.diagram.edges;
+
+/**
+ * An edge that joins the nodes in a constructor call.
+ */
+public final class ConstructorEdge extends CallEdge
+{
+	public ConstructorEdge()
+	{
+		super();
+		super.setMiddleLabel("\u00ABcreate\u00BB");
+	}
+}

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -41,6 +41,7 @@ import ca.mcgill.cs.jetuml.diagram.builder.ClassDiagramBuilder;
 import ca.mcgill.cs.jetuml.diagram.builder.CompoundOperation;
 import ca.mcgill.cs.jetuml.diagram.builder.DiagramBuilder;
 import ca.mcgill.cs.jetuml.diagram.builder.DiagramOperationProcessor;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Line;
 import ca.mcgill.cs.jetuml.geom.Point;
@@ -448,6 +449,11 @@ public class DiagramCanvasController
 		{
 			if( aDiagramBuilder.canAdd(newEdge, aMouseDownPoint, pMousePoint))
 			{
+				if(aDiagramBuilder.canCreateConstructorCall(pMousePoint))
+				{
+					// Change the edge type if can create a constructor call
+					newEdge = new ConstructorEdge();
+				}
 				aProcessor.executeNewOperation(aDiagramBuilder.createAddEdgeOperation(newEdge, 
 						aMouseDownPoint, pMousePoint));
 				aSelectionModel.set(newEdge);

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
@@ -23,7 +23,9 @@ package ca.mcgill.cs.jetuml.viewers.edges;
 import java.util.ArrayList;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.geom.Conversions;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -160,9 +162,9 @@ public final class CallEdgeViewer extends AbstractEdgeViewer
 	private Point[] getPoints(Edge pEdge)
 	{
 		ArrayList<Point> points = new ArrayList<>();
-		Rectangle start = NodeViewerRegistry.getBounds(pEdge.getStart());
-		Rectangle end = NodeViewerRegistry.getBounds(pEdge.getEnd());
-      
+		Node endNode = pEdge.getClass() == ConstructorEdge.class? pEdge.getEnd().getParent():pEdge.getEnd();
+		Rectangle start = NodeViewerRegistry.getBounds(pEdge.getStart());	
+		Rectangle end = NodeViewerRegistry.getBounds(endNode);
 		if( ((CallEdge)pEdge).isSelfEdge() )
 		{
 			Point p = new Point(start.getMaxX(), end.getY() - CallNode.CALL_YGAP / 2);
@@ -178,7 +180,7 @@ public final class CallEdgeViewer extends AbstractEdgeViewer
 		else     
 		{
 			Direction direction = new Direction(start.getX() - end.getX(), 0);
-			Point endPoint = NodeViewerRegistry.getConnectionPoints(pEdge.getEnd(), direction);
+			Point endPoint = NodeViewerRegistry.getConnectionPoints(endNode, direction);
          
 			if(start.getCenter().getX() < endPoint.getX())
 			{

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/EdgeViewerRegistry.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/EdgeViewerRegistry.java
@@ -17,6 +17,7 @@ import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.NoteEdge;
@@ -55,6 +56,7 @@ public final class EdgeViewerRegistry
 		aRegistry.put(StateTransitionEdge.class, new StateTransitionEdgeViewer());
 		aRegistry.put(ReturnEdge.class, new ReturnEdgeViewer());
 		aRegistry.put(CallEdge.class, new CallEdgeViewer());
+		aRegistry.put(ConstructorEdge.class, new CallEdgeViewer());
 		aRegistry.put(DependencyEdge.class, new DependencyEdgeViewer());
 		aRegistry.put(AssociationEdge.class,  new AssociationEdgeViewer());
 		aRegistry.put(GeneralizationEdge.class, new GeneralizationEdgeViewer());

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/CallNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/CallNodeViewer.java
@@ -116,12 +116,11 @@ public final class CallNodeViewer extends AbstractNodeViewer
 	 * of the caller or a set distance before the previous call node, whatever is lower.
 	 * If not, it's simply a set distance below the previous call node.
 	 */
-	private int getY(Node pNode)
+	private int getYWithNoConstructorCall(Node pNode)
 	{
 		final CallNode callNode = (CallNode) pNode;
 		final ImplicitParameterNode implicitParameterNode = (ImplicitParameterNode) callNode.getParent();
 		final Diagram diagram = callNode.getDiagram().get();
-		
 		if( implicitParameterNode == null || diagram == null )
 		{
 			return 0; // Only used for the ImageCreator
@@ -154,7 +153,7 @@ public final class CallNodeViewer extends AbstractNodeViewer
 			return IMPLICIT_PARAMETER_NODE_VIEWER.getTopRectangle(implicitParameterNode).getMaxY() + Y_GAP_SMALL;
 		}
 	} 
-	
+
 	/**
 	 * @param pNode the node.
 	 * @return If there's no callee, returns a fixed offset from the y position.
@@ -184,5 +183,34 @@ public final class CallNodeViewer extends AbstractNodeViewer
 	{
 		int y = getY(pNode);
 		return new Rectangle(getX(pNode), y, WIDTH, getMaxY(pNode) - y);
+	}
+	
+	private int getYWithConstructorCall(Node pNode) 
+	{
+		final ImplicitParameterNode implicitParameterNode = (ImplicitParameterNode) pNode.getParent();
+		return IMPLICIT_PARAMETER_NODE_VIEWER.getTopRectangle(implicitParameterNode).getMaxY() + Y_GAP_SMALL;
+	}
+
+	private boolean isInConstructorCall(Node pNode)
+	{
+		Optional<Diagram> diagram = pNode.getDiagram();
+		if(diagram.isPresent())
+		{
+			ControlFlow flow = new ControlFlow(diagram.get());
+			return flow.isInConstructorCall(pNode);
+		}
+		return false;
+	}
+	
+	protected int getY(Node pNode)
+	{
+		if(isInConstructorCall(pNode))
+		{
+			return getYWithConstructorCall(pNode);
+		}
+		else 
+		{
+			return getYWithNoConstructorCall(pNode);
+		}
 	}
 }

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
@@ -22,7 +22,13 @@ package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.Util.max;
 
+import java.util.List;
+import java.util.Optional;
+
+import ca.mcgill.cs.jetuml.diagram.ControlFlow;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
 import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 import ca.mcgill.cs.jetuml.geom.Direction;
 import ca.mcgill.cs.jetuml.geom.Point;
@@ -42,8 +48,10 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 	private static final int HORIZONTAL_PADDING = 10; // 2x the left and right padding around the name of the implicit parameter
 	private static final int TAIL_HEIGHT = 20; // Piece of the life line below the last call node
 	private static final int TOP_HEIGHT = 60;
+	private static final int Y_GAP_SMALL = 20; 
 	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, true);
-
+	private static final CallNodeViewer CALL_NODE_VIEWER = new CallNodeViewer();
+	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)
 	{
@@ -96,8 +104,9 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 	public Rectangle getTopRectangle(Node pNode)
 	{
 		int width = Math.max(NAME_VIEWER.getDimension(((ImplicitParameterNode)pNode).getName()).getWidth()+ 
-				HORIZONTAL_PADDING, DEFAULT_WIDTH); 
-		return new Rectangle(pNode.position().getX(), 0, width, TOP_HEIGHT);
+				HORIZONTAL_PADDING, DEFAULT_WIDTH);
+		int yVal = isInConstructorCall(pNode)?getYWithConstructorCall(pNode):0;
+		return new Rectangle(pNode.position().getX(), yVal, width, TOP_HEIGHT);
 	}
 
 	@Override
@@ -106,7 +115,76 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 		Rectangle topRectangle = getTopRectangle(pNode);
 		Point childrenMaxXY = getMaxXYofChildren(pNode);
 		int width = max(topRectangle.getWidth(), DEFAULT_WIDTH, childrenMaxXY.getX() - pNode.position().getX());
-		int height = max(DEFAULT_HEIGHT, childrenMaxXY.getY() + TAIL_HEIGHT);
-		return new Rectangle(pNode.position().getX(), 0, width, height);
+		List<Node> childNodes = ((ImplicitParameterNode)pNode).getChildren();
+		int height = max(DEFAULT_HEIGHT, childrenMaxXY.getY() + TAIL_HEIGHT);	
+		// Keep the default height only if the node is a constructor call with no child nodes
+		if( !isInConstructorCall(pNode) || childNodes.size()!=0 )
+		{
+			height -= topRectangle.getY();
+		}
+		return new Rectangle(pNode.position().getX(), topRectangle.getY(), width, height);
+	}
+	
+	private int getYWithConstructorCall(Node pNode) {
+		assert isInConstructorCall(pNode);
+		ControlFlow controlFlow = new ControlFlow(pNode.getDiagram().get());
+		CallNode child = (CallNode)getFirstChild(pNode).get();
+		// If the node is the first callee of its parent
+		if(controlFlow.isFirstCallee(child))
+		{
+			CallNode caller = controlFlow.getCaller(child).get(); 
+			return CALL_NODE_VIEWER.getY(caller) + Y_GAP_SMALL;
+		}
+		// If the node is not the first callee but the previous callee is in constructor call
+		else if(controlFlow.isInConstructorCall(controlFlow.getPreviousCallee(child)))
+		{
+			Node prevCallee = controlFlow.getPreviousCallee(child);
+			List<Node> prevCallees = controlFlow.getCallees(prevCallee);
+			if( prevCallees.size()==0 ) 
+			{
+				// Returns a fixed distance from the previous callee
+				return getBounds(prevCallee).getMaxY() + Y_GAP_SMALL;
+			}
+			else 
+			{
+				Node lastCallee = prevCallees.get(prevCallees.size()-1);
+				if(lastCallee instanceof CallNode)
+				{
+					return CALL_NODE_VIEWER.getMaxY(lastCallee) + Y_GAP_SMALL;
+				}
+				else 
+				{
+					return getYWithConstructorCall(lastCallee);
+				}
+			}
+			
+		}
+		// If the node is not the first callee but the previous callee is a call node 
+		else
+		{
+			return CALL_NODE_VIEWER.getMaxY(controlFlow.getPreviousCallee(child)) + Y_GAP_SMALL;
+		}
+	}
+
+	private boolean isInConstructorCall(Node pNode) {
+		Optional<Diagram> diagram = pNode.getDiagram();
+		if(diagram.isPresent())
+		{
+			ControlFlow flow = new ControlFlow(diagram.get());
+			Optional<Node> child = getFirstChild(pNode);
+			return child.isPresent() && flow.isInConstructorCall(child.get());
+		}	
+		return false;
+	}
+	
+	private Optional<Node> getFirstChild(Node pNode)
+	{
+		assert pNode!=null;
+		List<Node> children = pNode.getChildren();
+		if(!children.isEmpty()) 
+		{
+			return Optional.of(children.get(0));
+		}
+		return Optional.empty();
 	}
 }

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
@@ -133,12 +133,12 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 		// If the node is not the first callee but the previous callee is in constructor call
 		if( controlFlow.isInConstructorCall(prevCallee) )
 		{
-			// Returns a fixed distance from the previous callee'sparent
+			// Returns a fixed distance from the bound of the previous callee's parent
 			return getBounds(prevCallee.getParent()).getMaxY();
 		}
-		// If the node is not the first callee but the previous callee is a call node 
 		else
 		{
+			// Returns a fixed distance from the previous callee
 			return CALL_NODE_VIEWER.getMaxY(prevCallee) + Y_GAP_SMALL;
 		}
 	}

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import ca.mcgill.cs.jetuml.JavaFXLoader;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ReturnEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
@@ -62,6 +63,7 @@ public class TestControlFlow
 	private CallEdge aCallEdge4;
 	private CallEdge aCallEdge5;
 	private ReturnEdge aReturnEdge;
+	private ConstructorEdge aConstructorEdge;
 	
 	@BeforeAll
 	public static void setupClass()
@@ -91,6 +93,7 @@ public class TestControlFlow
 		aCallEdge4 = new CallEdge();
 		aCallEdge5 = new CallEdge();
 		aReturnEdge = new ReturnEdge();
+		aConstructorEdge = new ConstructorEdge();
 		createSampleDiagram1();
 	}
 	
@@ -213,5 +216,37 @@ public class TestControlFlow
 	{
 		assertSame(aCall3, aFlow.getPreviousCallee(aCall2));
 		assertSame(aCall2, aFlow.getPreviousCallee(aCall6));
+	}
+	
+	@Test
+	public void testIsInConstructorCall()
+	{
+		aConstructorEdge.connect(aCall1, aCall2, aDiagram);
+		aDiagram.addEdge(aConstructorEdge);
+		assertTrue(aFlow.isInConstructorCall(aCall2));
+	}
+	
+	@Test
+	public void testIsInConstructorCallWithWrongEdge()
+	{
+		aCallEdge1.connect(aCall1, aCall2, aDiagram);
+		aDiagram.addEdge(aCallEdge1);
+		assertFalse(aFlow.isInConstructorCall(aCall2));
+	}
+	
+	@Test
+	public void testIsInConstructorCallWithWrongNode()
+	{
+		aCallEdge1.connect(aCall1, aCall2, aDiagram);
+		aDiagram.addEdge(aCallEdge1);
+		assertFalse(aFlow.isInConstructorCall(aCall1));
+	}
+	
+	@Test
+	public void testIsInConstructorCallWithWrongNodeType()
+	{
+		aCallEdge1.connect(aCall1, aParameter1, aDiagram);
+		aDiagram.addEdge(aCallEdge1);
+		assertFalse(aFlow.isInConstructorCall(aParameter1));
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -112,4 +112,10 @@ public class TestSequenceDiagramBuilder
 		assertSame(aDefaultCallNode1, aImplicitParameterNode1.getChildren().get(0));
 		assertSame(aCallNode1, aImplicitParameterNode1.getChildren().get(1));
 	}
+	
+	@Test
+	public void testGetAdditionalEdgeConstraints()
+	{
+		
+	}
 }

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -21,6 +21,7 @@
 
 package ca.mcgill.cs.jetuml.diagram.builder;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -31,8 +32,10 @@ import org.junit.jupiter.api.Test;
 import ca.mcgill.cs.jetuml.JavaFXLoader;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
 import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 import ca.mcgill.cs.jetuml.geom.Point;
@@ -77,6 +80,11 @@ public class TestSequenceDiagramBuilder
 		return sum;
 	}
 	
+	private int numberOfEdges() 
+	{
+		return aDiagram.edges().size();
+	}
+	
 	/*
 	 * Add without the default call node. 
 	 */
@@ -112,10 +120,69 @@ public class TestSequenceDiagramBuilder
 		assertSame(aDefaultCallNode1, aImplicitParameterNode1.getChildren().get(0));
 		assertSame(aCallNode1, aImplicitParameterNode1.getChildren().get(1));
 	}
+	 
+	@Test
+	public void testCompleteEdgeAdditionOperationWithConstructorCall()
+	{
+		aImplicitParameterNode1.translate(0, 70);
+		aImplicitParameterNode2.translate(100, 70);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		
+		Point startPoint = new Point(40, 95);
+		Point endPoint = new Point(120, 40);
+		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		CompoundOperation result = new CompoundOperation();
+		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
+		result.execute();
+		
+		assertEquals(2, numberOfRootNodes());
+		assertEquals(1, numberOfEdges());
+		Edge edge = aDiagram.edges().get(0);
+		assertTrue(edge.getClass() == ConstructorEdge.class);
+	}
 	
 	@Test
-	public void testGetAdditionalEdgeConstraints()
+	public void testCompleteEdgeAdditionOperationWithoutConstructorCall()
 	{
+		aImplicitParameterNode1.translate(0, 70);
+		aImplicitParameterNode2.translate(100, 70);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
 		
+		Point startPoint = new Point(40, 95);
+		Point endPoint = new Point(120, 90);
+		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		CompoundOperation result = new CompoundOperation();
+		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
+		result.execute();
+		
+		assertEquals(2, numberOfRootNodes());
+		assertEquals(1, numberOfEdges());
+		Edge edge = aDiagram.edges().get(0);
+		assertTrue(edge.getClass() == CallEdge.class);
+	}
+	
+	@Test
+	public void testCompleteEdgeAdditionOperationWithCallNodes()
+	{
+		aImplicitParameterNode1.translate(0, 70);
+		aImplicitParameterNode2.translate(100, 70);
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aImplicitParameterNode1.addChild(aDefaultCallNode2);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		
+		Point startPoint = new Point(40, 95);
+		Point endPoint = new Point(120, 90);
+		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		CompoundOperation result = new CompoundOperation();
+		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aDefaultCallNode1, aDefaultCallNode2, startPoint, endPoint);
+		result.execute();
+		
+		assertEquals(2, numberOfRootNodes());
+		assertEquals(1, numberOfEdges());
+		Edge edge = aDiagram.edges().get(0);
+		assertTrue(edge.getClass() == CallEdge.class);
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -21,6 +21,7 @@
 
 package ca.mcgill.cs.jetuml.diagram.builder;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -32,12 +33,13 @@ import org.junit.jupiter.api.Test;
 import ca.mcgill.cs.jetuml.JavaFXLoader;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
 import ca.mcgill.cs.jetuml.diagram.DiagramType;
-import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.NoteEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.NoteNode;
 import ca.mcgill.cs.jetuml.geom.Point;
 
 public class TestSequenceDiagramBuilder
@@ -48,7 +50,6 @@ public class TestSequenceDiagramBuilder
 	private ImplicitParameterNode aImplicitParameterNode2;
 	private CallNode aDefaultCallNode1;
 	private CallNode aDefaultCallNode2;
-	private CallNode aCallNode1;
 	private CallEdge aCallEdge1;
 	
 	@BeforeAll
@@ -66,7 +67,6 @@ public class TestSequenceDiagramBuilder
 		aImplicitParameterNode2 = new ImplicitParameterNode();
 		aDefaultCallNode1 = new CallNode();
 		aDefaultCallNode2 = new CallNode();
-		aCallNode1 = new CallNode();
 		aCallEdge1 = new CallEdge();
 	}
 	
@@ -113,12 +113,13 @@ public class TestSequenceDiagramBuilder
 		aCallEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
 		aDiagram.addEdge(aCallEdge1);
 		
-		DiagramOperation operation = aBuilder.createAddNodeOperation(aCallNode1, new Point(30, 135));
+		CallNode callNode = new CallNode();
+		DiagramOperation operation = aBuilder.createAddNodeOperation(callNode, new Point(30, 135));
 		operation.execute();
 		assertEquals(2, numberOfRootNodes());
 		assertEquals(2, aImplicitParameterNode1.getChildren().size());
 		assertSame(aDefaultCallNode1, aImplicitParameterNode1.getChildren().get(0));
-		assertSame(aCallNode1, aImplicitParameterNode1.getChildren().get(1));
+		assertSame(callNode, aImplicitParameterNode1.getChildren().get(1));
 	}
 	 
 	@Test
@@ -132,14 +133,19 @@ public class TestSequenceDiagramBuilder
 		Point startPoint = new Point(40, 95);
 		Point endPoint = new Point(120, 40);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		assert aBuilder.canCreateConstructorCall(endPoint);
 		CompoundOperation result = new CompoundOperation();
-		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
+		ConstructorEdge constructorEdge = new ConstructorEdge();
+		aBuilder.completeEdgeAdditionOperation(result, constructorEdge, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
 		result.execute();
 		
 		assertEquals(2, numberOfRootNodes());
 		assertEquals(1, numberOfEdges());
-		Edge edge = aDiagram.edges().get(0);
-		assertTrue(edge.getClass() == ConstructorEdge.class);
+		assertEquals(1, aImplicitParameterNode1.getChildren().size());
+		assertEquals(1, aImplicitParameterNode2.getChildren().size());
+		assertTrue(aImplicitParameterNode1.getChildren().get(0).getClass() == CallNode.class);
+		assertTrue(aImplicitParameterNode2.getChildren().get(0).getClass() == CallNode.class);
+		assertSame(aDiagram.edges().get(0), constructorEdge);
 	}
 	
 	@Test
@@ -153,14 +159,18 @@ public class TestSequenceDiagramBuilder
 		Point startPoint = new Point(40, 95);
 		Point endPoint = new Point(120, 90);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		assertFalse( aBuilder.canCreateConstructorCall(endPoint) );
 		CompoundOperation result = new CompoundOperation();
 		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
 		result.execute();
 		
 		assertEquals(2, numberOfRootNodes());
 		assertEquals(1, numberOfEdges());
-		Edge edge = aDiagram.edges().get(0);
-		assertTrue(edge.getClass() == CallEdge.class);
+		assertEquals(1, aImplicitParameterNode1.getChildren().size());
+		assertEquals(1, aImplicitParameterNode2.getChildren().size());
+		assertTrue(aImplicitParameterNode1.getChildren().get(0).getClass() == CallNode.class);
+		assertTrue(aImplicitParameterNode2.getChildren().get(0).getClass() == CallNode.class);
+		assertSame(aDiagram.edges().get(0), aCallEdge1);
 	}
 	
 	@Test
@@ -169,20 +179,47 @@ public class TestSequenceDiagramBuilder
 		aImplicitParameterNode1.translate(0, 70);
 		aImplicitParameterNode2.translate(100, 70);
 		aImplicitParameterNode1.addChild(aDefaultCallNode1);
-		aImplicitParameterNode1.addChild(aDefaultCallNode2);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
 		aDiagram.addRootNode(aImplicitParameterNode1);
 		aDiagram.addRootNode(aImplicitParameterNode2);
 		
 		Point startPoint = new Point(40, 95);
-		Point endPoint = new Point(120, 90);
+		Point endPoint = new Point(120, 70);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
+		assertFalse( aBuilder.canCreateConstructorCall(endPoint) );
 		CompoundOperation result = new CompoundOperation();
 		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aDefaultCallNode1, aDefaultCallNode2, startPoint, endPoint);
 		result.execute();
 		
 		assertEquals(2, numberOfRootNodes());
 		assertEquals(1, numberOfEdges());
-		Edge edge = aDiagram.edges().get(0);
-		assertTrue(edge.getClass() == CallEdge.class);
+		assertEquals(1, aImplicitParameterNode1.getChildren().size());
+		// TODO: Fix the addition of the extra call node
+		assertEquals(2, aImplicitParameterNode2.getChildren().size());
+		assertSame(aDefaultCallNode1, aImplicitParameterNode1.getChildren().get(0));
+		assertSame(aDefaultCallNode2, aImplicitParameterNode2.getChildren().get(0));
+		assertSame(aDiagram.edges().get(0), aCallEdge1);
+	}
+	
+	@Test
+	public void testCompleteEdgeAdditionOperationWithNoteEdge()
+	{
+		NoteEdge noteEdge = new NoteEdge();
+		NoteNode noteNode = new NoteNode();
+		aImplicitParameterNode1.translate(0, 70);
+		noteNode.translate(100, 70);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(noteNode);
+		
+		Point startPoint = new Point(40, 95);
+		Point endPoint = new Point(120, 90);
+		assert aBuilder.canAdd(noteEdge, startPoint, endPoint);
+		CompoundOperation result = new CompoundOperation();
+		aBuilder.completeEdgeAdditionOperation(result, noteEdge, aDefaultCallNode1, aDefaultCallNode2, startPoint, endPoint);
+		result.execute();
+		
+		assertEquals(2, numberOfRootNodes());
+		assertEquals(1, numberOfEdges());
+		assertSame(aDiagram.edges().get(0), noteEdge);
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestCallNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestCallNodeViewer.java
@@ -30,6 +30,7 @@ import ca.mcgill.cs.jetuml.JavaFXLoader;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
 import ca.mcgill.cs.jetuml.diagram.DiagramType;
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
@@ -44,6 +45,7 @@ public class TestCallNodeViewer
 	private CallNode aCallNode1;
 	private CallEdge aCallEdge1;
 	private CallEdge aCallEdge2;
+	private ConstructorEdge aConstructorEdge;
 	
 	@BeforeAll
 	public static void setupClass()
@@ -62,6 +64,7 @@ public class TestCallNodeViewer
 		aCallNode1 = new CallNode();
 		aCallEdge1 = new CallEdge();
 		aCallEdge2 = new CallEdge();
+		aConstructorEdge = new ConstructorEdge();
 	}
 	
 	@Test
@@ -74,6 +77,7 @@ public class TestCallNodeViewer
 		aImplicitParameterNode2.translate(200, 0);
 		aDiagram.addRootNode(aImplicitParameterNode1);
 		aDiagram.addRootNode(aImplicitParameterNode2);
+		
 		aCallEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
 		aDiagram.addEdge(aCallEdge1);
 		
@@ -86,4 +90,21 @@ public class TestCallNodeViewer
 		assertEquals(new Rectangle(232, 100, 16, 30), NodeViewerRegistry.getBounds(aDefaultCallNode2));
 		assertEquals(new Rectangle(232, 150, 16, 30), NodeViewerRegistry.getBounds(aCallNode1));
 	}	
+	
+	@Test
+	public void testGetBoundsWithConstructorCall()
+	{
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aDefaultCallNode1.attach(aDiagram);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDefaultCallNode2.attach(aDiagram);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		
+		aConstructorEdge.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aDiagram.addEdge(aConstructorEdge);
+		
+		assertEquals(new Rectangle(32, 80, 16, 150), NodeViewerRegistry.getBounds(aDefaultCallNode1));
+		assertEquals(new Rectangle(32, 180, 16, 30), NodeViewerRegistry.getBounds(aDefaultCallNode2));
+	}
 }

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestImplicitParameterNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestImplicitParameterNodeViewer.java
@@ -1,0 +1,144 @@
+/**
+ * 
+ */
+package ca.mcgill.cs.jetuml.viewers.nodes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ca.mcgill.cs.jetuml.JavaFXLoader;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+
+/**
+ * @author Madonna Huang
+ *
+ */
+public class TestImplicitParameterNodeViewer 
+{
+	private ImplicitParameterNode aImplicitParameterNode1;
+	private ImplicitParameterNode aImplicitParameterNode2;
+	private ImplicitParameterNode aImplicitParameterNode3;
+	private Diagram aDiagram;
+	private CallNode aDefaultCallNode1;
+	private CallNode aDefaultCallNode2;
+	private CallNode aCallNode1;
+	private CallEdge aCallEdge1;
+	private ConstructorEdge aConstructorEdge1;
+	private ConstructorEdge aConstructorEdge2;
+	
+	@BeforeAll
+	public static void setupClass()
+	{
+		JavaFXLoader.load();
+	}
+	
+	@BeforeEach
+	public void setup()
+	{
+		aDiagram = new Diagram(DiagramType.SEQUENCE);
+		aImplicitParameterNode1 = new ImplicitParameterNode();
+		aImplicitParameterNode2 = new ImplicitParameterNode();
+		aImplicitParameterNode3 = new ImplicitParameterNode();
+		aDefaultCallNode1 = new CallNode();
+		aDefaultCallNode2 = new CallNode();
+		aCallNode1 = new CallNode();
+		aCallEdge1 = new CallEdge();
+		aConstructorEdge1 = new ConstructorEdge();
+		aConstructorEdge2 = new ConstructorEdge();
+	}
+	
+	@Test
+	public void testGetBoundsWithOneNode()
+	{
+		assertEquals(new Rectangle(0, 0, 80, 120), NodeViewerRegistry.getBounds(aImplicitParameterNode1));
+	}
+	
+	@Test
+	public void testGetBoundsWithOneNodeInDiagram()
+	{
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		assertEquals(new Rectangle(0, 0, 80, 120), NodeViewerRegistry.getBounds(aImplicitParameterNode1));
+	}
+	
+	@Test
+	public void testGetBoundsContructorCallWithFirstCallee()
+	{
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aDefaultCallNode1.attach(aDiagram);
+		
+		aImplicitParameterNode2.translate(100, 0);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDefaultCallNode2.attach(aDiagram);
+		
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		
+		aConstructorEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aDiagram.addEdge(aConstructorEdge1);
+		assertEquals(new Rectangle(0, 0, 80, 250), NodeViewerRegistry.getBounds(aImplicitParameterNode1));
+		assertEquals(new Rectangle(100, 100, 80, 130), NodeViewerRegistry.getBounds(aImplicitParameterNode2));
+	}
+	
+	@Test
+	public void testGetBoundsContructorCallWithSecondCallCallee1()
+	{
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aDefaultCallNode1.attach(aDiagram);
+		
+		aImplicitParameterNode2.translate(100, 0);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDefaultCallNode2.attach(aDiagram);
+		
+		aImplicitParameterNode3.translate(200, 0);
+		aImplicitParameterNode3.addChild(aCallNode1);
+		
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		aDiagram.addRootNode(aImplicitParameterNode3);
+		
+		aCallEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aConstructorEdge1.connect(aDefaultCallNode1, aCallNode1, aDiagram);
+		aDiagram.addEdge(aCallEdge1);
+		aDiagram.addEdge(aConstructorEdge1);
+		
+		assertEquals(new Rectangle(0, 0, 80, 300), NodeViewerRegistry.getBounds(aImplicitParameterNode1));
+		assertEquals(new Rectangle(100, 0, 80, 150), NodeViewerRegistry.getBounds(aImplicitParameterNode2));
+		assertEquals(new Rectangle(200, 150, 80, 130), NodeViewerRegistry.getBounds(aImplicitParameterNode3));
+	}
+	
+	@Test
+	public void testGetBoundsContructorCallWithSecondCallCallee2()
+	{
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aDefaultCallNode1.attach(aDiagram);
+		
+		aImplicitParameterNode2.translate(100, 0);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDefaultCallNode2.attach(aDiagram);
+		
+		aImplicitParameterNode3.translate(200, 0);
+		aImplicitParameterNode3.addChild(aCallNode1);
+		
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		aDiagram.addRootNode(aImplicitParameterNode3);
+		
+		aConstructorEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aConstructorEdge2.connect(aDefaultCallNode1, aCallNode1, aDiagram);
+		aDiagram.addEdge(aConstructorEdge1);
+		aDiagram.addEdge(aConstructorEdge2);
+		
+		assertEquals(new Rectangle(0, 0, 80, 380), NodeViewerRegistry.getBounds(aImplicitParameterNode1));
+		assertEquals(new Rectangle(100, 100, 80, 130), NodeViewerRegistry.getBounds(aImplicitParameterNode2));
+		assertEquals(new Rectangle(200, 230, 80, 130), NodeViewerRegistry.getBounds(aImplicitParameterNode3));
+	}
+}


### PR DESCRIPTION
**Summary of Changes**

- Create a new type of edge `ConstructorEdge` which is inherited from the CallEdge.
- Use the `CallEdgeViewer` for drawing the `ConstructorEdge`.
- Modify the edge constraints to allow constructor call.

**Achieved Performance**

- A new type of edge to better distinguish the constructor call.
- Can create constructor call when the call edge lands on the `ImplicitParameterNode`.

**Concerns**

- The label of the `ConstructorEdge` is set to  "create" with bracket symbols by default. However, since we are inheriting directly from the CallEdge, which is a subclass of `SingleLabelEdge`, we can still change the label after creation.
