### PR TITLE
#340 Modify the Drawing of Package Nodes

### DIFF
--- a/src/ca/mcgill/cs/jetuml/diagram/builder/ClassDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/ClassDiagramBuilder.java
@@ -42,6 +42,8 @@ import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
  */
 public class ClassDiagramBuilder extends DiagramBuilder
 {
+	private static final int PADDING = 10;
+	private static final int TOP_HEIGHT = 20;
 	/**
 	 * Creates a new builder for class diagrams.
 	 * 
@@ -63,7 +65,13 @@ public class ClassDiagramBuilder extends DiagramBuilder
 			Optional<PackageNode> container = findContainer(aDiagram.rootNodes(), pRequestedPosition);
 			if( container.isPresent() )
 			{
-				positionNode(pNode, pRequestedPosition);
+				if( container.get().getChildren().size()==0 )
+				{
+					positionNode(pNode, new Point(container.get().position().getX() + PADDING, container.get().position().getY() + PADDING + TOP_HEIGHT));
+				}else 
+				{
+					positionNode(pNode, pRequestedPosition);
+				}
 				result = new SimpleOperation( ()->  
 				{ 
 					pNode.attach(aDiagram);

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/ClassDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/ClassDiagramBuilder.java
@@ -44,6 +44,7 @@ public class ClassDiagramBuilder extends DiagramBuilder
 {
 	private static final int PADDING = 10;
 	private static final int TOP_HEIGHT = 20;
+	
 	/**
 	 * Creates a new builder for class diagrams.
 	 * 
@@ -67,8 +68,10 @@ public class ClassDiagramBuilder extends DiagramBuilder
 			{
 				if( container.get().getChildren().size()==0 )
 				{
+					// If pNode would be the first child node, position the node according to its container's position
 					positionNode(pNode, new Point(container.get().position().getX() + PADDING, container.get().position().getY() + PADDING + TOP_HEIGHT));
-				}else 
+				}
+				else 
 				{
 					positionNode(pNode, pRequestedPosition);
 				}

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageNodeViewer.java
@@ -134,9 +134,7 @@ public final class PackageNodeViewer extends AbstractNodeViewer
 		{
 			return pNode.position();
 		}
-		int x = Math.min(pNode.position().getX(), pChildrenBounds.get().getX() - PADDING);
-		int y = Math.min(pNode.position().getY(), pChildrenBounds.get().getY() - PADDING - TOP_HEIGHT);
-		return new Point(x, y);
+		return new Point(pChildrenBounds.get().getX() - PADDING, pChildrenBounds.get().getY() - PADDING - TOP_HEIGHT);
 	}
 	
 	private Dimension getTopDimension(Node pNode)

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestClassDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestClassDiagramBuilder.java
@@ -182,7 +182,7 @@ public class TestClassDiagramBuilder
 		
 		assertEquals(1, node.getChildren().size());
 		assertSame(node2, node.getChildren().get(0));
-		assertEquals(new Point(10,10), node2.position());
+		assertEquals(new Point(10,30), node2.position());
 		
 		operation.undo();
 		assertEquals(0, node.getChildren().size());
@@ -203,7 +203,7 @@ public class TestClassDiagramBuilder
 		assertSame(middle, bottom.getChildren().get(0));
 		
 		InterfaceNode top = new InterfaceNode();
-		aBuilder.createAddNodeOperation(top, new Point(20,20)).execute();
+		aBuilder.createAddNodeOperation(top, new Point(20,40)).execute();
 		assertEquals(1, numberOfRootNodes());
 		assertSame(bottom, getRootNode(0));
 		assertEquals(1, bottom.getChildren().size());


### PR DESCRIPTION
**Summary of Changes**

- Modify the position of the `PackageNode` returned by the method. 
- Change the positioning of the first child node created within the  `PackageNode` to be wrapped tightly.

**Achieved Behaviour**

- When drawing the 1st node, the `PackageNode` would always wraps its child tightly.
- When drawing multiple nodes, we can still adjust the package node’s size by moving the child nodes around, but we could not move the `PackageNode` by its children.
