### PR TITLE
#353 Modify the control-flow of element deletion in Sequence Diagram

### DIFF
--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ReturnEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 
@@ -374,13 +375,14 @@ public final class ControlFlow
 		}
 		return downstreamElements;
 	}
-	private boolean calledOntheSameObject(List<CallEdge> pEdges, Node pParentNode)
+	
+	private boolean onlyCallsOneObject(Node pCaller, Node pParentNode)
 	{
-		assert pEdges!= null && pParentNode != null;
-		return pEdges.stream().allMatch(pEdge -> pEdge.getEnd().getParent() == pParentNode);
+		assert pCaller!= null && pParentNode != null;
+		return getCalls(pCaller).stream().allMatch(edge -> edge.getEnd().getParent() == pParentNode);
 	}
 	
-	private boolean onlyConnectedToOneCallEdge(Node pNode, Edge pEdge)
+	private boolean onlyConnectedToOneEdge(Node pNode, Edge pEdge)
 	{
 		assert pNode != null && pEdge != null;
 		List<CallEdge> calls = getCalls(pNode);
@@ -389,21 +391,15 @@ public final class ControlFlow
 				calls.contains(pEdge);
 	}
 	
-	private List<DiagramElement> getUpstreamElements(Node pCaller, Node pParent)
+	private Optional<Edge> getReturnEdge(Edge pEdge)
 	{
-		assert pCaller != null && pParent != null;
-		List<DiagramElement> elements = new ArrayList<>();
-		for( Edge e: getCalls(pCaller))
+		for( Edge edge : aDiagram.edges() )
 		{
-			if ( e.getEnd().getParent() == pParent)
+			if( edge.getClass() == ReturnEdge.class && edge.getStart() == pEdge.getEnd() && edge.getEnd() == pEdge.getStart() )
 			{
-				elements.add(e);
+				return Optional.of(edge);
 			}
 		}
-		if( elements.size() == getCalls(pCaller).size())
-		{
-			elements.add(pCaller);
-		}
-		return elements;
-	}	
+		return Optional.empty();
+	}
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -454,4 +454,26 @@ public final class ControlFlow
 		}
 		return Optional.empty();
 	}	
+	
+	/**
+	 * @param pElements the DiagramElements to obtain the corresponding ReturnEdges for.
+	 * @return the Collection of corresponding ReturnEdges for pElements.
+	 */
+	public Collection<DiagramElement> getCorrespondingReturnEdges(List<DiagramElement> pElements)
+	{
+		assert pElements != null;
+		Set<DiagramElement> returnEdges = new HashSet<>();
+		for( DiagramElement element: pElements )
+		{
+			if( element instanceof CallEdge )
+			{
+				Optional<Edge> returnEdge = getReturnEdge((Edge) element);
+				if( returnEdge.isPresent() )
+				{
+					returnEdges.add(returnEdge.get());
+				}
+			}
+		}
+		return returnEdges;
+	}
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -374,4 +374,36 @@ public final class ControlFlow
 		}
 		return downstreamElements;
 	}
+	private boolean calledOntheSameObject(List<CallEdge> pEdges, Node pParentNode)
+	{
+		assert pEdges!= null && pParentNode != null;
+		return pEdges.stream().allMatch(pEdge -> pEdge.getEnd().getParent() == pParentNode);
+	}
+	
+	private boolean onlyConnectedToOneCallEdge(Node pNode, Edge pEdge)
+	{
+		assert pNode != null && pEdge != null;
+		List<CallEdge> calls = getCalls(pNode);
+		return  getCaller(pNode).isEmpty() &&
+				calls.size() == 1 &&
+				calls.contains(pEdge);
+	}
+	
+	private List<DiagramElement> getUpstreamElements(Node pCaller, Node pParent)
+	{
+		assert pCaller != null && pParent != null;
+		List<DiagramElement> elements = new ArrayList<>();
+		for( Edge e: getCalls(pCaller))
+		{
+			if ( e.getEnd().getParent() == pParent)
+			{
+				elements.add(e);
+			}
+		}
+		if( elements.size() == getCalls(pCaller).size())
+		{
+			elements.add(pCaller);
+		}
+		return elements;
+	}	
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -69,9 +69,9 @@ public final class ControlFlow
 	{
 		assert pNode != null && aDiagram.contains(pNode);
 		List<Node> callees = new ArrayList<>();
-		for(Edge edge : aDiagram.edges() )
+		for( Edge edge : aDiagram.edges() )
 		{
-			if ( edge.getStart() == pNode && edge instanceof CallEdge)
+			if ( edge.getStart() == pNode && edge instanceof CallEdge )
 			{
 				callees.add(edge.getEnd());
 			}
@@ -182,9 +182,9 @@ public final class ControlFlow
 		assert pNode != null;
 		int result = 0;
 		Optional<CallNode> node = getCaller(pNode);
-		while(node.isPresent())
+		while( node.isPresent() )
 		{
-			if(node.get().getParent() == pNode.getParent())
+			if( node.get().getParent() == pNode.getParent() )
 			{
 				result++;
 			}
@@ -229,7 +229,7 @@ public final class ControlFlow
 		{
 			return false;
 		}
-		for(Edge edge : aDiagram.edges())
+		for( Edge edge : aDiagram.edges() )
 		{
 			if ( edge.getEnd() == pNode && edge.getClass() == ConstructorEdge.class )
 			{
@@ -245,13 +245,13 @@ public final class ControlFlow
 	private boolean isConstructedObject(Node pNode)
 	{
 		assert pNode != null;
-		return pNode.getClass() == ImplicitParameterNode.class && pNode.getChildren().size()>0 &&
+		return pNode.getClass() == ImplicitParameterNode.class && pNode.getChildren().size() > 0 &&
 				isConstructorExecution(getFirstChild(pNode));
 	}
 	
 	private Node getFirstChild(Node pNode)
 	{
-		assert pNode.getChildren().size()>0;
+		assert pNode.getChildren().size() > 0;
 		return pNode.getChildren().get(0);
 	}
 	
@@ -262,7 +262,7 @@ public final class ControlFlow
 		{
 			return Optional.empty();	
 		}
-		for(Edge edge : aDiagram.edges())
+		for( Edge edge : aDiagram.edges() )
 		{
 			if ( edge.getEnd() == pNode && edge.getClass() == ConstructorEdge.class )
 			{
@@ -273,44 +273,46 @@ public final class ControlFlow
 	}
 
 	/**
-	 * @param pEdge the Edge to get downstream elements from 
-	 * @return the downstream DiagramElements of pEdge
-	 * @pre pEdge!=null
+	 * @param pEdge The Edge to get downstream elements from.
+	 * @return The downstream DiagramElements of pEdge.
+	 * @pre pEdge != null
 	 */
 	public Collection<DiagramElement> getEdgeDownStreams(Edge pEdge)
 	{
-		assert pEdge!=null;
+		assert pEdge != null;
 		Set<DiagramElement> downstreamElements = new HashSet<>();
+		
 		// The edge addition here is necessary for recursive calls
 		downstreamElements.add(pEdge);
-		if(pEdge.getClass() == ConstructorEdge.class)
+		if( pEdge.getClass() == ConstructorEdge.class )
 		{
 			Node endParent = pEdge.getEnd().getParent();
 			downstreamElements.add(endParent);
 			downstreamElements.addAll(endParent.getChildren());
 			
 			// Recursively add downstream elements of the child nodes
-			for(Node child: endParent.getChildren())
+			for( Node child: endParent.getChildren() )
 			{
-				for(Edge edge: getCalls(child))
+				for( Edge edge: getCalls(child) )
 				{
 					downstreamElements.addAll(getEdgeDownStreams(edge));
 				}
+				
 				// Add upstream edges of the child nodes
-				for(Edge edge: aDiagram.edges())
+				for( Edge edge: aDiagram.edges() )
 				{
-					if(edge.getEnd() == child)
+					if( edge.getEnd() == child )
 					{
 						downstreamElements.add(edge);
 					}
 				}
 			}
 		}
-		else if(pEdge.getClass() == CallEdge.class)
+		else if( pEdge.getClass() == CallEdge.class )
 		{
 			CallNode endNode = (CallNode)pEdge.getEnd();
 			downstreamElements.add(endNode);
-			for(Edge e: getCalls(endNode))
+			for( Edge e: getCalls(endNode) )
 			{
 				downstreamElements.addAll(getEdgeDownStreams(e));
 			}
@@ -319,43 +321,43 @@ public final class ControlFlow
 	}
 
 	/** 
-	 * @param pNode the Node to get downstream elements from 
-	 * @return the downstream DiagramElements of pNode excluding pNode
+	 * @param pNode The Node to obtain downstream elements from.
+	 * @return The downstream DiagramElements of pNode.
 	 * @pre pNode!=null
 	 */
 	public Collection<DiagramElement> getNodeDownStreams(Node pNode)
 	{
 		assert pNode!=null;
 		Set<DiagramElement> downstreamElements = new HashSet<>();
-		if(isConstructorExecution(pNode))
+		if( isConstructorExecution(pNode) )
 		{
 			Optional<Edge> constructorEdge = getConstructorEdge(pNode);
-			if(constructorEdge.isPresent())
+			if( constructorEdge.isPresent() )
 			{
 				downstreamElements.addAll(getEdgeDownStreams(constructorEdge.get()));
 			}
 		}
-		else if(isConstructedObject(pNode))
+		else if( isConstructedObject(pNode) )
 		{
 			Optional<Edge> constructorEdge = getConstructorEdge(getFirstChild(pNode));
-			if(constructorEdge.isPresent())
+			if( constructorEdge.isPresent() )
 			{
 				downstreamElements.addAll(getEdgeDownStreams(constructorEdge.get()));
 			}
 		}
-		else if(pNode.getClass() == CallNode.class)
+		else if( pNode.getClass() == CallNode.class )
 		{
-			for(Edge edge: getCalls(pNode))
+			for( Edge edge: getCalls(pNode) )
 			{
 				downstreamElements.addAll(getEdgeDownStreams(edge));
 			}
 		}
-		else if (pNode.getClass() == ImplicitParameterNode.class)
+		else if ( pNode.getClass() == ImplicitParameterNode.class )
 		{
 			downstreamElements.addAll(pNode.getChildren());
-			for(Node child: pNode.getChildren())
+			for( Node child: pNode.getChildren() )
 			{
-				for(Edge edge: getCalls(child))
+				for( Edge edge: getCalls(child) )
 				{
 					downstreamElements.addAll(getEdgeDownStreams(edge));
 				}
@@ -392,15 +394,16 @@ public final class ControlFlow
 	}
 	
 	/**
-	 * @param pNode the Node to obtain the caller and upstream DiagramElements for.
-	 * @return the Collection of DiagramElements in the upstream of pNode.
-	 *     Excludes pNode and elements returned by getCoRemovals in the DiagramBuilder class.
+	 * @param pNode The Node to obtain the caller and upstream DiagramElements for.
+	 * @return The Collection of DiagramElements in the upstream of pNode.
+	 *     Excludes pNode and elements returned by getCoRemovals method in the DiagramBuilder class.
+	 * @pre pNode != null
 	 */
 	public Collection<DiagramElement> getNodeUpstreams(Node pNode)
 	{
 		assert pNode != null;
 		Set<DiagramElement> elements = new HashSet<>();
-		if( pNode.getClass() == CallNode.class)
+		if( pNode.getClass() == CallNode.class )
 		{
 			Optional<CallNode> caller = getCaller(pNode);
 			if( caller.isPresent() && getCaller(caller.get()).isEmpty() )
@@ -422,9 +425,9 @@ public final class ControlFlow
 				}
 			}
 		}
-		else if( pNode.getClass() == ImplicitParameterNode.class && pNode.getChildren().size() > 0)
+		else if( pNode.getClass() == ImplicitParameterNode.class && pNode.getChildren().size() > 0 )
 		{
-			Optional<CallNode> caller = getCaller(pNode.getChildren().get(0));
+			Optional<CallNode> caller = getCaller(getFirstChild(pNode));
 			if( caller.isPresent() && getCaller(caller.get()).isEmpty() && onlyCallsOneObject(caller.get(), pNode) )
 			{
 				elements.add(caller.get());
@@ -434,8 +437,9 @@ public final class ControlFlow
 	}
 	
 	/**
-	 * @param pEdge the Edge to obtain the edge start for.
-	 * @return the Optional value of the start Node for pEdge.
+	 * @param pEdge The Edge to obtain the edge start for.
+	 * @return The Optional value of the start Node for pEdge.
+	 * @pre pEdge != null
 	 */
 	public Optional<DiagramElement> getEdgeStart(Edge pEdge)
 	{
@@ -456,8 +460,8 @@ public final class ControlFlow
 	}	
 	
 	/**
-	 * @param pElements the DiagramElements to obtain the corresponding ReturnEdges for.
-	 * @return the Collection of corresponding ReturnEdges for pElements.
+	 * @param pElements The DiagramElements to obtain the corresponding ReturnEdges for.
+	 * @return The Collection of corresponding ReturnEdges for pElements.
 	 */
 	public Collection<DiagramElement> getCorrespondingReturnEdges(List<DiagramElement> pElements)
 	{

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -255,6 +255,7 @@ public abstract class DiagramBuilder
 	{
 		assert pElement != null && aDiagram.contains(pElement);
 		ArrayList<DiagramElement> result = new ArrayList<>();
+		result.add(pElement);
 		if( pElement.getClass() == PointNode.class )
 		{
 			for( Edge edge : aDiagram.edgesConnectedTo((Node)pElement))
@@ -370,7 +371,7 @@ public abstract class DiagramBuilder
 		Set<DiagramElement> toDelete = new HashSet<>();
 		for( DiagramElement element : pElements)
 		{
-			toDelete.add(element);
+			//toDelete.add(element);
 			toDelete.addAll(getCoRemovals(element));
 		}
 		CompoundOperation result = new CompoundOperation();

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -371,7 +371,6 @@ public abstract class DiagramBuilder
 		Set<DiagramElement> toDelete = new HashSet<>();
 		for( DiagramElement element : pElements)
 		{
-			//toDelete.add(element);
 			toDelete.addAll(getCoRemovals(element));
 		}
 		CompoundOperation result = new CompoundOperation();

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -25,8 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,12 +61,10 @@ public class TestControlFlow
 	private CallNode aCall3;
 	private CallNode aCall4;
 	private CallNode aCall5;
-	private CallNode aCall6;
 	private CallEdge aCallEdge1;
 	private CallEdge aCallEdge2;
 	private CallEdge aCallEdge3;
 	private CallEdge aCallEdge4;
-	private CallEdge aCallEdge5;
 	private ReturnEdge aReturnEdge;
 	private ConstructorEdge aConstructorEdge;
 	
@@ -89,12 +89,10 @@ public class TestControlFlow
 		aCall3 = new CallNode();
 		aCall4 = new CallNode();
 		aCall5 = new CallNode();
-		aCall6 = new CallNode();
 		aCallEdge1 = new CallEdge();
 		aCallEdge2 = new CallEdge();
 		aCallEdge3 = new CallEdge();
 		aCallEdge4 = new CallEdge();
-		aCallEdge5 = new CallEdge();
 		aReturnEdge = new ReturnEdge();
 		aConstructorEdge = new ConstructorEdge();
 		createSampleDiagram1();
@@ -115,17 +113,15 @@ public class TestControlFlow
 		aDiagram.addRootNode(aParameter2);
 		aDiagram.addRootNode(aParameter3);
 		aParameter1.addChild(aCall1);
-		aParameter1.addChild(aCall2);
+		aParameter2.addChild(aCall2);
 		aParameter2.addChild(aCall3);
-		aParameter2.addChild(aCall4);
+		aParameter3.addChild(aCall4);
 		aParameter3.addChild(aCall5);
-		aParameter3.addChild(aCall6);
-		aDiagramAccessor.connectAndAdd(aCallEdge1, aCall1, aCall3);
-		aDiagramAccessor.connectAndAdd(aCallEdge2, aCall1, aCall2);
-		aDiagramAccessor.connectAndAdd(aCallEdge3, aCall2, aCall4);
-		aDiagramAccessor.connectAndAdd(aReturnEdge, aCall4, aCall2);
-		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall4, aCall5);
-		aDiagramAccessor.connectAndAdd(aCallEdge5, aCall1, aCall6);
+		aDiagramAccessor.connectAndAdd(aConstructorEdge, aCall1, aCall2);
+		aDiagramAccessor.connectAndAdd(aReturnEdge, aCall2, aCall1);
+		aDiagramAccessor.connectAndAdd(aCallEdge1, aCall2, aCall3);
+		aDiagramAccessor.connectAndAdd(aCallEdge2, aCall3, aCall4);
+		aDiagramAccessor.connectAndAdd(aCallEdge3, aCall2, aCall5);
 	}
 	
 	@Test
@@ -137,135 +133,120 @@ public class TestControlFlow
 	@Test
 	public void testGetCallerSameParameter()
 	{
-		assertSame( aCall1, aFlow.getCaller(aCall2).get());
+		assertSame( aCall2, aFlow.getCaller(aCall3).get());
 	}
 	
 	@Test
 	public void testGetCallerDifferentParameter()
 	{
-		assertSame( aCall1, aFlow.getCaller(aCall3).get());
-		assertSame( aCall2, aFlow.getCaller(aCall4).get());
-		assertSame( aCall4, aFlow.getCaller(aCall5).get());
-		assertSame( aCall1, aFlow.getCaller(aCall6).get());
+		assertSame( aCall1, aFlow.getCaller(aCall2).get());
+		assertSame( aCall2, aFlow.getCaller(aCall3).get());
+		assertSame( aCall3, aFlow.getCaller(aCall4).get());
+		assertSame( aCall2, aFlow.getCaller(aCall5).get());
 	}
 	
 	@Test
 	public void testGetCalleesEmpty()
 	{
-		assertTrue( aFlow.getCallees(aCall3).isEmpty());
+		assertTrue( aFlow.getCallees(aCall4).isEmpty());
 		assertTrue( aFlow.getCallees(aCall5).isEmpty());
-		assertTrue( aFlow.getCallees(aCall6).isEmpty());
 	}
 	
 	@Test
 	public void testGetCalleesSingle()
 	{
-		List<Node> callees = aFlow.getCallees(aCall2);
+		List<Node> callees = aFlow.getCallees(aCall1);
+		assertEquals(1, callees.size());
+		assertSame(aCall2, callees.get(0));
+		
+		callees = aFlow.getCallees(aCall3);
 		assertEquals(1, callees.size());
 		assertSame(aCall4, callees.get(0));
-		
-		callees = aFlow.getCallees(aCall4);
-		assertEquals(1, callees.size());
-		assertSame(aCall5, callees.get(0));
 	}
 	
 	@Test
 	public void testGetCalleesMultiple()
 	{
-		List<Node> callees = aFlow.getCallees(aCall1);
-		assertEquals(3, callees.size());
-		assertTrue( callees.contains(aCall2));
-		assertTrue( callees.contains(aCall3));
-		assertTrue( callees.contains(aCall6));
+		List<Node> callees = aFlow.getCallees(aCall2);
+		assertEquals(2, callees.size());
+		assertTrue(callees.contains(aCall3));
+		assertTrue(callees.contains(aCall5));
 	}
 	
 	@Test
-	public void testGetCalleesIsNestedNoCaller()
+	public void testIsNestedNoCaller()
 	{
 		assertFalse(aFlow.isNested(aCall1));
 	}
 	
 	@Test
-	public void testGetCalleesIsNestedTrue()
+	public void testIsNestedTrue()
 	{
-		assertTrue(aFlow.isNested(aCall2));
+		assertTrue(aFlow.isNested(aCall3));
 	}
 	
 	@Test
-	public void testGetCalleesIsNestedFalse()
+	public void testIsNestedFalse()
 	{
-		assertFalse(aFlow.isNested(aCall3));
+		assertFalse(aFlow.isNested(aCall2));
 		assertFalse(aFlow.isNested(aCall4));
 		assertFalse(aFlow.isNested(aCall5));
-		assertFalse(aFlow.isNested(aCall6));
 	}
 	
 	@Test
 	public void testIsFirstCalleeTrue()
 	{
+		assertTrue(aFlow.isFirstCallee(aCall2));
 		assertTrue(aFlow.isFirstCallee(aCall3));
 		assertTrue(aFlow.isFirstCallee(aCall4));
-		assertTrue(aFlow.isFirstCallee(aCall5));
 	}
 	
 	@Test
 	public void testIsFirstCalleeFalse()
 	{
-		assertFalse(aFlow.isFirstCallee(aCall2));
-		assertFalse(aFlow.isFirstCallee(aCall6));
+		assertFalse(aFlow.isFirstCallee(aCall5));
 	}
 	
 	@Test
 	public void testGetPreviousCallee()
 	{
-		assertSame(aCall3, aFlow.getPreviousCallee(aCall2));
-		assertSame(aCall2, aFlow.getPreviousCallee(aCall6));
+		CallNode callNode = new CallNode();
+		aParameter2.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, callNode);
+		assertSame(aCall2, aFlow.getPreviousCallee(callNode));
 	}
 	
-	/*
-	 * @Todo
-	 */
 	@Test
-	public void testIsInConstructorCall()
+	public void testIsConstructorExecutionInConstructorCall()
 	{
-		aConstructorEdge.connect(aCall1, aCall2, aDiagram);
-		aDiagram.addEdge(aConstructorEdge);
 		assertTrue(aFlow.isConstructorExecution(aCall2));
 	}
 	
 	@Test
-	public void testIsInConstructorCallWithWrongEdge()
+	public void testIsConstructorExecutionNotInConstructorCall()
 	{
-		aCallEdge1.connect(aCall1, aCall2, aDiagram);
-		aDiagram.addEdge(aCallEdge1);
-		assertFalse(aFlow.isConstructorExecution(aCall2));
+		assertFalse(aFlow.isConstructorExecution(aCall4));
 	}
 	
 	@Test
 	public void testIsInConstructorCallWithWrongNode()
 	{
-		aCallEdge1.connect(aCall1, aCall2, aDiagram);
-		aDiagram.addEdge(aCallEdge1);
-		assertFalse(aFlow.isConstructorExecution(aCall1));
+		assertFalse(aFlow.isConstructorExecution(aCall3));
 	}
 	
 	@Test
 	public void testIsInConstructorCallWithWrongNodeType()
 	{
-		aCallEdge1.connect(aCall1, aParameter1, aDiagram);
-		aDiagram.addEdge(aCallEdge1);
-		assertFalse(aFlow.isConstructorExecution(aParameter1));
+		assertFalse(aFlow.isConstructorExecution(aParameter2));
 	}
 	
 	@Test
 	public void testGetEdgeDownStreamsCallEdge()
 	{
-		Collection<DiagramElement> downstreams = aFlow.getEdgeDownStreams(aCallEdge3);
-		assertEquals(4, downstreams.size());
+		Collection<DiagramElement> downstreams = aFlow.getEdgeDownStreams(aCallEdge2);
+		assertEquals(2, downstreams.size());
 		assertTrue( downstreams.contains(aCall4));
-		assertTrue( downstreams.contains(aCall5));
-		assertTrue( downstreams.contains(aCallEdge3));
-		assertTrue( downstreams.contains(aCallEdge4));
+		assertTrue( downstreams.contains(aCallEdge2));
 	}
 	
 	@Test
@@ -283,38 +264,28 @@ public class TestControlFlow
 	@Test
 	public void testGetNodeDownStreamsWithConstructorCall()
 	{
-		aDiagramAccessor.connectAndAdd(aConstructorEdge, aCall1, aCall3);
-		Collection<DiagramElement> downstreams1 = aFlow.getNodeDownStreams(aCall3);
+		Collection<DiagramElement> downstreams1 = aFlow.getNodeDownStreams(aCall2);
 		Collection<DiagramElement> downstreams2 = aFlow.getNodeDownStreams(aParameter2);
 		assertEquals(downstreams1, downstreams2);
+		assertEquals(9, downstreams1.size());
 		assertTrue(downstreams1.contains(aConstructorEdge));
 		assertTrue(downstreams1.contains(aCallEdge1));
-		assertTrue(downstreams1.contains(aCallEdge3));
-		assertTrue(downstreams1.contains(aCallEdge4));	
+		assertTrue(downstreams1.contains(aCallEdge2));
+		assertTrue(downstreams1.contains(aCallEdge3));	
 		assertTrue(downstreams1.contains(aParameter2));
+		assertTrue(downstreams1.contains(aCall2));
 		assertTrue(downstreams1.contains(aCall3));
 		assertTrue(downstreams1.contains(aCall4));
 		assertTrue(downstreams1.contains(aCall5));
 	}
 	
 	@Test
-	public void testGetNodeDownStreamsParameter()
-	{
-		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aParameter2);
-		assertEquals(4, downstreams.size());
-		assertTrue(downstreams.contains(aCall3));
-		assertTrue(downstreams.contains(aCall4));
-		assertTrue(downstreams.contains(aCall5));
-		assertTrue(downstreams.contains(aCallEdge4));	
-	}
-	
-	@Test
 	public void testGetNodeDownStreamsCallNode()
 	{
-		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aCall4);
+		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aCall3);
 		assertEquals(2, downstreams.size());
-		assertTrue(downstreams.contains(aCall5));
-		assertTrue(downstreams.contains(aCallEdge4));
+		assertTrue(downstreams.contains(aCall4));
+		assertTrue(downstreams.contains(aCallEdge2));
 	}
 	
 	@Test
@@ -324,5 +295,183 @@ public class TestControlFlow
 		aDiagram.addRootNode(noteNode);
 		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(noteNode);
 		assertEquals(0, downstreams.size());
+	}
+	
+	@Test
+	public void testGetNodeDownStreamsParameter()
+	{
+		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aParameter1);
+		assertEquals(10, downstreams.size());
+		assertTrue(downstreams.contains(aParameter2));
+		assertTrue(downstreams.contains(aCall1));
+		assertTrue(downstreams.contains(aCall2));
+		assertTrue(downstreams.contains(aCall3));
+		assertTrue(downstreams.contains(aCall4));
+		assertTrue(downstreams.contains(aCall5));
+		assertTrue(downstreams.contains(aCallEdge1));
+		assertTrue(downstreams.contains(aCallEdge2));
+		assertTrue(downstreams.contains(aCallEdge3));
+		assertTrue(downstreams.contains(aConstructorEdge));
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsIfNoOtherFlows()
+	{
+		Collection<DiagramElement> upstreams = aFlow.getNodeUpstreams(aCall2);
+		assertEquals(1, upstreams.size());
+		assertTrue(upstreams.contains(aCall1));
+	}
+
+	@Test
+	public void testGetNodeUpstreamsIfHasOtherFlows()
+	{
+		CallNode callNode = new CallNode();
+		aParameter3.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, callNode);
+		assertEquals(0, aFlow.getNodeUpstreams(callNode).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsIfHasOtherFlowsInConstructorExecution()
+	{
+		CallNode callNode = new CallNode();
+		aParameter2.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, callNode);
+		Collection<DiagramElement> upstreams = aFlow.getNodeUpstreams(aCall2);
+		assertEquals(3, upstreams.size());
+		assertTrue(upstreams.contains(aConstructorEdge));
+		assertTrue(upstreams.contains(aCall1));
+		assertTrue(upstreams.contains(aCallEdge4));
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsHasOtherFlowBesidesConstructorCall()
+	{
+		CallNode call1 = new CallNode();
+		CallNode call2 = new CallNode();
+		CallEdge callEdge = new CallEdge();
+		aParameter2.addChild(call1);
+		aParameter3.addChild(call2);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, call1);
+		aDiagramAccessor.connectAndAdd(callEdge, aCall1, call2);
+		
+		Collection<DiagramElement> upstreams = aFlow.getNodeUpstreams(aCall2);
+		assertEquals(2, upstreams.size());
+		assertTrue(upstreams.contains(aConstructorEdge));
+		assertTrue(upstreams.contains(aCallEdge4));
+		assertEquals(0, aFlow.getNodeUpstreams(aParameter2).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsWithNestedCallers()
+	{
+		assertEquals(0, aFlow.getNodeUpstreams(aCall4).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsNoteNode()
+	{
+		NoteNode noteNode = new NoteNode();
+		aDiagram.addRootNode(noteNode);
+		assertEquals(0, aFlow.getNodeUpstreams(noteNode).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsConstructedObject()
+	{
+		Collection<DiagramElement> upstreams = aFlow.getNodeUpstreams(aParameter2);
+		assertEquals(1, upstreams.size());
+		assertTrue(upstreams.contains(aCall1));
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsUnconnectedParameter()
+	{
+		ImplicitParameterNode parameter = new ImplicitParameterNode();
+		aDiagram.addRootNode(parameter);
+		assertEquals(0, aFlow.getNodeUpstreams(parameter).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsParameterWithNoCaller()
+	{
+		assertEquals(0, aFlow.getNodeUpstreams(aParameter1).size());
+	}
+	
+	@Test
+	public void testGetNodeUpstreamsParameterWithNestedCallers()
+	{
+		assertEquals(0, aFlow.getNodeUpstreams(aParameter3).size());
+	}
+	
+	@Test 
+	public void testGetEdgeStartNoteEdge()
+	{
+		NoteNode noteNode = new NoteNode();
+		NoteEdge noteEdge = new NoteEdge();
+		aDiagramAccessor.connectAndAdd(noteEdge, aCall1, noteNode);
+		assertTrue(aFlow.getEdgeStart(noteEdge).isEmpty());
+	}
+	
+	@Test 
+	public void testGetEdgeStartHasNoOtherFlows()
+	{
+		Optional<DiagramElement> start = aFlow.getEdgeStart(aConstructorEdge);
+		assertTrue(start.isPresent());
+		assertSame(aCall1, start.get());
+	}
+	
+	@Test 
+	public void testGetEdgeStartHasOtherFlowsInConstructorCall()
+	{
+		CallNode callNode = new CallNode();
+		aParameter2.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, callNode);
+		
+		Optional<DiagramElement> start = aFlow.getEdgeStart(aConstructorEdge);
+		assertTrue(start.isPresent());
+		assertSame(aCall1, start.get());
+	}
+	
+	@Test 
+	public void testGetEdgeStartHasOtherFlowsBesidesConstructorCall()
+	{
+		CallNode callNode = new CallNode();
+		aParameter3.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(aCallEdge4, aCall1, callNode);
+		
+		Optional<DiagramElement> start = aFlow.getEdgeStart(aConstructorEdge);
+		assertTrue(start.isEmpty());
+	}
+	
+	@Test 
+	public void testGetEdgeStartHasOtherFlowsNestedConstructorCall()
+	{
+		ImplicitParameterNode parameter = new ImplicitParameterNode();
+		CallNode  callNode = new CallNode();
+		ConstructorEdge constructorEdge = new ConstructorEdge();
+		aDiagram.addRootNode(parameter);
+		parameter.addChild(callNode);
+		aDiagramAccessor.connectAndAdd(constructorEdge, aCall2, callNode);
+		
+		Optional<DiagramElement> start = aFlow.getEdgeStart(constructorEdge);
+		assertTrue(start.isEmpty());
+	}
+	
+	@Test
+	public void testGetCorrespondingReturnEdges()
+	{
+		ReturnEdge returnEdge1 = new ReturnEdge();
+		aDiagramAccessor.connectAndAdd(returnEdge1, aCall4, aCall3);
+		List<DiagramElement> elements = new ArrayList<>();
+		elements.add(aConstructorEdge);
+		elements.add(aCallEdge2);
+		elements.add(aCallEdge3);
+		elements.add(aCall1);
+		
+		Collection<DiagramElement> returnEdges = aFlow.getCorrespondingReturnEdges(elements);
+		assertEquals(2, returnEdges.size());
+		assertTrue(returnEdges.contains(aReturnEdge));
+		assertTrue(returnEdges.contains(returnEdge1));
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -281,37 +281,20 @@ public class TestControlFlow
 	}
 	
 	@Test
-	public void testGetNodeDownStreamsCallNodeInConstructorCall()
+	public void testGetNodeDownStreamsWithConstructorCall()
 	{
-		aConstructorEdge.connect(aCall1, aCall3, aDiagram);
-		aDiagram.addEdge(aConstructorEdge);
-		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aCall3);
-		assertEquals(8, downstreams.size());
-		assertTrue(downstreams.contains(aConstructorEdge));
-		assertTrue(downstreams.contains(aCallEdge1));
-		assertTrue(downstreams.contains(aCallEdge3));
-		assertTrue(downstreams.contains(aCallEdge4));	
-		assertTrue(downstreams.contains(aParameter2));
-		assertTrue(downstreams.contains(aCall3));
-		assertTrue(downstreams.contains(aCall4));
-		assertTrue(downstreams.contains(aCall5));
-	}
-	
-	@Test
-	public void testGetNodeDownStreamsParameterInConstructorCall()
-	{
-		aConstructorEdge.connect(aCall1, aCall3, aDiagram);
-		aDiagram.addEdge(aConstructorEdge);
-		Collection<DiagramElement> downstreams = aFlow.getNodeDownStreams(aParameter2);
-		assertEquals(8, downstreams.size());
-		assertTrue(downstreams.contains(aConstructorEdge));
-		assertTrue(downstreams.contains(aCallEdge1));
-		assertTrue(downstreams.contains(aCallEdge3));
-		assertTrue(downstreams.contains(aCallEdge4));	
-		assertTrue(downstreams.contains(aParameter2));
-		assertTrue(downstreams.contains(aCall3));
-		assertTrue(downstreams.contains(aCall4));
-		assertTrue(downstreams.contains(aCall5));
+		aDiagramAccessor.connectAndAdd(aConstructorEdge, aCall1, aCall3);
+		Collection<DiagramElement> downstreams1 = aFlow.getNodeDownStreams(aCall3);
+		Collection<DiagramElement> downstreams2 = aFlow.getNodeDownStreams(aParameter2);
+		assertEquals(downstreams1, downstreams2);
+		assertTrue(downstreams1.contains(aConstructorEdge));
+		assertTrue(downstreams1.contains(aCallEdge1));
+		assertTrue(downstreams1.contains(aCallEdge3));
+		assertTrue(downstreams1.contains(aCallEdge4));	
+		assertTrue(downstreams1.contains(aParameter2));
+		assertTrue(downstreams1.contains(aCall3));
+		assertTrue(downstreams1.contains(aCall4));
+		assertTrue(downstreams1.contains(aCall5));
 	}
 	
 	@Test

--- a/test/ca/mcgill/cs/jetuml/diagram/TestUsageScenariosSequenceDiagram.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestUsageScenariosSequenceDiagram.java
@@ -210,8 +210,8 @@ public class TestUsageScenariosSequenceDiagram extends AbstractTestUsageScenario
 		select(aParameterNode1);
 		deleteSelected();
 		assertEquals(2, numberOfRootNodes());
-		assertEquals(1, newParameterNode.getChildren().size());
-		assertEquals(1, aParameterNode2.getChildren().size()); 
+		assertEquals(0, newParameterNode.getChildren().size());
+		assertEquals(0, aParameterNode2.getChildren().size()); 
 		assertEquals(0, numberOfEdges());
 		
 		undo();

--- a/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
+++ b/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
@@ -404,7 +404,7 @@ public class TestPersistenceService
 		assertEquals(node8, edge5.getEnd());
 		
 		DependencyEdge edge6 = (DependencyEdge) eIterator.next();
-		assertEquals(new Rectangle(378, osDependent(390,383, 384), 83, osDependent(23,22, 21)), getBounds(edge6));
+		assertEquals(new Rectangle(378, osDependent(390,390, 384), 83, osDependent(23,23, 21)), getBounds(edge6));
 		assertEquals(node7, edge6.getEnd());
 		assertEquals("e1", edge6.getMiddleLabel());
 		assertEquals(node1, edge6.getStart());
@@ -415,7 +415,7 @@ public class TestPersistenceService
 		assertEquals(node1, edge1.getStart());
 		
 		GeneralizationEdge edge2 = (GeneralizationEdge) eIterator.next();
-		assertEquals(new Rectangle(503, 428, osDependent(12,13, 25), 92), getBounds(edge2));
+		assertEquals(new Rectangle(503, 428, osDependent(12,12, 25), 92), getBounds(edge2));
 		assertEquals(node1, edge2.getEnd());
 		assertEquals(node3, edge2.getStart());
 		


### PR DESCRIPTION
**Summary of Changes**
- Added methods to obtain the upstream `DiagramElement`s.
- Added the method to obtain the corresponding `ReturnEdge`s.
- Modified and added new tests.
- Updated the code documentation.

**Sample Diagram**
Below is the sample diagram created in the `TestControlFlow` class.
![Sample Diagram](https://user-images.githubusercontent.com/55864124/84443887-88088200-ac0e-11ea-94c7-e8fe40bf95ce.jpg)
