### PR TITLE
#369 Modify constraints in the Sequence Diagram for constructor call creation

### DIFF
--- a/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/ControlFlow.java
@@ -33,6 +33,8 @@ import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ReturnEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.viewers.nodes.ImplicitParameterNodeViewer;
 
 /**
  * An immutable wrapper around a SequenceDiagram that can answer
@@ -479,5 +481,19 @@ public final class ControlFlow
 			}
 		}
 		return returnEdges;
+	}
+
+	/**
+	 * @param pNode The Node to check if it can create a constructed object.
+	 * @param pPoint The point to check if it is within the top rectangular bound of pNode.
+	 * @return True if pNode is an ImplicitParameterNode with no child nodes and pPoint is within the top rectangular bound of pNode.
+	 * @pre pNode != null && pPoint != null
+	 */
+	public boolean canCreateConstructedObject(Node pNode, Point pPoint)
+	{
+		assert pNode != null && pPoint != null;
+		return pNode instanceof ImplicitParameterNode && 
+				new ImplicitParameterNodeViewer().getTopRectangle(pNode).contains(pPoint) && 
+				pNode.getChildren().size()==0;
 	}
 }

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -173,7 +173,6 @@ public abstract class DiagramBuilder
 		DiagramViewer viewer = viewerFor(aDiagram);
 		Optional<Node> end = viewer.findNode(aDiagram, pEnd);
 		Optional<Node> start = viewer.findNode(aDiagram, pStart);
-		
 		if(start.isPresent() && end.isPresent())
 		{
 			Node startNode = start.get();

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -163,29 +163,6 @@ public abstract class DiagramBuilder
 	}
 	
 	/**
-	 * Returns whether a constructor call could be created.
-	 * @param pStart the start position of the mouse
-	 * @param pEnd the end position of the mouse
-	 * @return True if the end node of the edge is an ImplicitParameterNode with no child nodes.
-	 */
-	public boolean canCreateConstructorCall(Point pStart, Point pEnd)
-	{
-		DiagramViewer viewer = viewerFor(aDiagram);
-		Optional<Node> end = viewer.findNode(aDiagram, pEnd);
-		Optional<Node> start = viewer.findNode(aDiagram, pStart);
-		if(start.isPresent() && end.isPresent())
-		{
-			Node startNode = start.get();
-			Node endNode = end.get();
-			return 	startNode instanceof ImplicitParameterNode && 
-					endNode instanceof ImplicitParameterNode && 
-					new ImplicitParameterNodeViewer().getTopRectangle(endNode).contains(pEnd) && 
-					endNode.getChildren().size()==0;
-		}
-		return false;
-	}
-	
-	/**
 	 * @param pEdge The edge to add.
 	 * @param pStart The start node.
 	 * @param pEnd The end node.

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/DiagramBuilder.java
@@ -164,15 +164,26 @@ public abstract class DiagramBuilder
 	
 	/**
 	 * Returns whether a constructor call could be created.
-	 * @param pEnd The node to check.
+	 * @param pStart the start position of the mouse
+	 * @param pEnd the end position of the mouse
 	 * @return True if the end node of the edge is an ImplicitParameterNode with no child nodes.
 	 */
-	public boolean canCreateConstructorCall(Point pEnd)
+	public boolean canCreateConstructorCall(Point pStart, Point pEnd)
 	{
 		DiagramViewer viewer = viewerFor(aDiagram);
-		Node endNode = viewer.findNode(aDiagram, pEnd).get();
-		return endNode instanceof ImplicitParameterNode && new ImplicitParameterNodeViewer().getTopRectangle(endNode).contains(pEnd) && 
-				((ImplicitParameterNode)endNode).getChildren().size()==0;
+		Optional<Node> end = viewer.findNode(aDiagram, pEnd);
+		Optional<Node> start = viewer.findNode(aDiagram, pStart);
+		
+		if(start.isPresent() && end.isPresent())
+		{
+			Node startNode = start.get();
+			Node endNode = end.get();
+			return 	startNode instanceof ImplicitParameterNode && 
+					endNode instanceof ImplicitParameterNode && 
+					new ImplicitParameterNodeViewer().getTopRectangle(endNode).contains(pEnd) && 
+					endNode.getChildren().size()==0;
+		}
+		return false;
 	}
 	
 	/**

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -70,7 +70,7 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 				SequenceDiagramEdgeConstraints.returnEdge(pEdge, pStart, pEnd, aDiagram),
 				SequenceDiagramEdgeConstraints.singleEntryPoint(pEdge, pStart, aDiagram)
 			);
-		if( !canCreateConstructorCall(pEndPoint) )
+		if( !canCreateConstructorCall(pStartPoint, pEndPoint) )
 		{
 			// The edge could not land on the top rectangle of ImplicitParameterNode if cannot create constructor call
 			constraintSet.merge( new ConstraintSet(SequenceDiagramEdgeConstraints.callEdgeEnd(pEdge, pEnd, pEndPoint)) );

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -21,6 +21,8 @@
 
 package ca.mcgill.cs.jetuml.diagram.builder;
 
+import static ca.mcgill.cs.jetuml.diagram.DiagramType.viewerFor;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -40,6 +42,7 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.viewers.edges.EdgeViewerRegistry;
 import ca.mcgill.cs.jetuml.viewers.nodes.ImplicitParameterNodeViewer;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+import ca.mcgill.cs.jetuml.views.DiagramViewer;
 
 /**
  * A builder for sequence diagrams.
@@ -76,6 +79,30 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 			constraintSet.merge( new ConstraintSet(SequenceDiagramEdgeConstraints.callEdgeEnd(pEdge, pEnd, pEndPoint)) );
 		}
 		return constraintSet;
+	}
+	
+	/**
+	 * Check if the start node is either a CallNode or ImplicitParameterNode, and the end node is an ImplicitParameterNode
+	 * with no child nodes. The end point of the edge should land on the top rectangle of the end Node.
+	 * @param pStart the start position of the mouse.
+	 * @param pEnd the end position of the mouse.
+	 * @return True if the start node and the end node of the edge satisfy the conditions to create the constructor call.
+	 * @pre pStart!= null && pEnd != null
+	 */
+	public boolean canCreateConstructorCall(Point pStart, Point pEnd)
+	{
+		assert pStart!= null && pEnd != null;
+		DiagramViewer viewer = viewerFor(aDiagram);
+		Optional<Node> end = viewer.findNode(aDiagram, pEnd);
+		Optional<Node> start = viewer.findNode(aDiagram, pStart);
+		if(start.isPresent() && end.isPresent())
+		{
+			Node startNode = start.get();
+			Node endNode = end.get();
+			return 	(startNode instanceof ImplicitParameterNode || startNode instanceof CallNode) && 
+					new ControlFlow(aDiagram).canCreateConstructedObject(endNode, pEnd);
+		}
+		return false;
 	}
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -41,6 +41,7 @@ import ca.mcgill.cs.jetuml.diagram.builder.ClassDiagramBuilder;
 import ca.mcgill.cs.jetuml.diagram.builder.CompoundOperation;
 import ca.mcgill.cs.jetuml.diagram.builder.DiagramBuilder;
 import ca.mcgill.cs.jetuml.diagram.builder.DiagramOperationProcessor;
+import ca.mcgill.cs.jetuml.diagram.builder.SequenceDiagramBuilder;
 import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.PackageNode;
@@ -465,7 +466,8 @@ public class DiagramCanvasController
 		{
 			if( aDiagramBuilder.canAdd(newEdge, aMouseDownPoint, pMousePoint))
 			{
-				if(aDiagramBuilder.canCreateConstructorCall(aMouseDownPoint, pMousePoint))
+				if( aDiagramBuilder instanceof SequenceDiagramBuilder &&
+						((SequenceDiagramBuilder)aDiagramBuilder).canCreateConstructorCall(aMouseDownPoint, pMousePoint))
 				{
 					// Change the edge type if can create a constructor call
 					newEdge = new ConstructorEdge();

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -447,7 +447,7 @@ public class DiagramCanvasController
 		{
 			if( aDiagramBuilder.canAdd(newEdge, aMouseDownPoint, pMousePoint))
 			{
-				if(aDiagramBuilder.canCreateConstructorCall(pMousePoint))
+				if(aDiagramBuilder.canCreateConstructorCall(aMouseDownPoint, pMousePoint))
 				{
 					// Change the edge type if can create a constructor call
 					newEdge = new ConstructorEdge();

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -42,6 +42,7 @@ import ca.mcgill.cs.jetuml.diagram.edges.ReturnEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.NoteNode;
+import ca.mcgill.cs.jetuml.geom.Point;
 
 /*
  * This class is used to test the methods of SequenceDiagram
@@ -473,5 +474,11 @@ public class TestControlFlow
 		assertEquals(2, returnEdges.size());
 		assertTrue(returnEdges.contains(aReturnEdge));
 		assertTrue(returnEdges.contains(returnEdge1));
+	}
+	
+	@Test
+	public void testCanCreateConstructedObjectParameterWithChild()
+	{	
+		assertFalse(aFlow.canCreateConstructedObject(aParameter3, new Point(0, 0)));
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -133,7 +133,7 @@ public class TestSequenceDiagramBuilder
 		Point startPoint = new Point(40, 95);
 		Point endPoint = new Point(120, 40);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
-		assert aBuilder.canCreateConstructorCall(endPoint);
+		assert aBuilder.canCreateConstructorCall(startPoint, endPoint);
 		CompoundOperation result = new CompoundOperation();
 		ConstructorEdge constructorEdge = new ConstructorEdge();
 		aBuilder.completeEdgeAdditionOperation(result, constructorEdge, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
@@ -159,7 +159,7 @@ public class TestSequenceDiagramBuilder
 		Point startPoint = new Point(40, 95);
 		Point endPoint = new Point(120, 90);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
-		assertFalse( aBuilder.canCreateConstructorCall(endPoint) );
+		assertFalse( aBuilder.canCreateConstructorCall(startPoint, endPoint) );
 		CompoundOperation result = new CompoundOperation();
 		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aImplicitParameterNode1, aImplicitParameterNode2, startPoint, endPoint);
 		result.execute();
@@ -186,7 +186,7 @@ public class TestSequenceDiagramBuilder
 		Point startPoint = new Point(40, 95);
 		Point endPoint = new Point(120, 70);
 		assert aBuilder.canAdd(aCallEdge1, startPoint, endPoint);
-		assertFalse( aBuilder.canCreateConstructorCall(endPoint) );
+		assertFalse( aBuilder.canCreateConstructorCall(startPoint, endPoint) );
 		CompoundOperation result = new CompoundOperation();
 		aBuilder.completeEdgeAdditionOperation(result, aCallEdge1, aDefaultCallNode1, aDefaultCallNode2, startPoint, endPoint);
 		result.execute();
@@ -194,7 +194,6 @@ public class TestSequenceDiagramBuilder
 		assertEquals(2, numberOfRootNodes());
 		assertEquals(1, numberOfEdges());
 		assertEquals(1, aImplicitParameterNode1.getChildren().size());
-		// TODO: Fix the addition of the extra call node
 		assertEquals(2, aImplicitParameterNode2.getChildren().size());
 		assertSame(aDefaultCallNode1, aImplicitParameterNode1.getChildren().get(0));
 		assertSame(aDefaultCallNode2, aImplicitParameterNode2.getChildren().get(0));

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -221,4 +221,24 @@ public class TestSequenceDiagramBuilder
 		assertEquals(1, numberOfEdges());
 		assertSame(aDiagram.edges().get(0), noteEdge);
 	}
+	
+	@Test
+	public void testCanCreateConstructorCallNoNodes()
+	{
+		assertFalse(aBuilder.canCreateConstructorCall(new Point(0, 0), new Point(20, 20)));
+	}
+	
+	@Test
+	public void testCanCreateConstructorCallWrongStartNode()
+	{
+		aDiagram.addRootNode(new NoteNode());
+		assertFalse(aBuilder.canCreateConstructorCall(new Point(0, 0), new Point(20, 20)));
+	}
+	
+	@Test
+	public void testCanCreateConstructorCallNoEndNode()
+	{
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		assertFalse(aBuilder.canCreateConstructorCall(new Point(0, 0), new Point(150, 150)));
+	}
 }


### PR DESCRIPTION
**Summary of Changes**

- Moved the `canCreateConstructorCall` method to the `SequenceDiagramBuilder` class.
- Modified the `canCreateConstructorCall` method to constrain the start node of the constructor call to be either an `ImplicitParameterNode` with no child nodes or a `CallNode`.
- Added a helper method in the class `ControlFlow`.
- Added tests for corresponding methods.

**Concerns**

- The class `DiagramBuilder` cannot be tested directly since it is an abstract class.
