### PR TITLE
[#328] Support zooming the diagram

### DIFF
--- a/src/ca/mcgill/cs/jetuml/JetUML.properties
+++ b/src/ca/mcgill/cs/jetuml/JetUML.properties
@@ -276,6 +276,18 @@ view.autoedit_node.icon=16x16/document-edit.png
 view.diagram_size.text=Set Diagram Size
 view.diagram_size.mnemonic=D
 view.diagram_size.icon=16x16/zoom-fit-width.png
+view.zoom_in.text=Zoom In
+view.zoom_in.mnemonic=I
+view.zoom_in.accelerator.mac=META+'='
+view.zoom_in.accelerator=CTRL+'='
+view.zoom_out.text=Zoom Out
+view.zoom_out.mnemonic=O
+view.zoom_out.accelerator.mac=META+'-'
+view.zoom_out.accelerator=CTRL+'-'
+view.reset_zoom.text=Reset Zoom
+view.reset_zoom.mnemonic=R
+view.reset_zoom.accelerator.mac=META+0
+view.reset_zoom.accelerator=CTRL+0
 help.text=Help
 help.mnemonic=H
 help.about.text=About

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramTab.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramTab.java
@@ -29,7 +29,10 @@ import java.util.Optional;
 import ca.mcgill.cs.jetuml.application.UserPreferences;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
 import ca.mcgill.cs.jetuml.geom.Point;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.geometry.Bounds;
+import javafx.scene.Group;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Tab;
 import javafx.scene.layout.BorderPane;
@@ -40,6 +43,9 @@ import javafx.scene.layout.StackPane;
  */
 public class DiagramTab extends Tab implements MouseDraggedGestureHandler, KeyEventHandler
 {
+	private static final double DEFAULT_SCALE = 1.0;
+	private static final double SCALE_MULTIPLIER = 1.25;
+	private final DoubleProperty aScaleProperty;
 	private final Diagram aDiagram;
 	private DiagramCanvas aDiagramCanvas;
 	private final DiagramCanvasController aDiagramCanvasController;
@@ -73,9 +79,15 @@ public class DiagramTab extends Tab implements MouseDraggedGestureHandler, KeyEv
 				+ "-fx-border-width: 1; -fx-border-style: solid;";
 		pane.setStyle(cssDefault);
 		
-		// We wrap pane within an additional, resizable StackPane that can grow to fit the parent
+		aScaleProperty = new SimpleDoubleProperty(DEFAULT_SCALE);
+		pane.scaleXProperty().bind(aScaleProperty);
+		pane.scaleYProperty().bind(aScaleProperty);
+		
+		// First, wrap the StackPane in a Group to allow the scrolling to be based around the visual bounds
+		// of the canvas rather than its layout bounds.
+		// Then we wrap the Group within an additional, resizable StackPane that can grow to fit the parent
 		// ScrollPane and thus center the decorated canvas.
-		ScrollPane scroll = new ScrollPane(new StackPane(pane));
+		ScrollPane scroll = new ScrollPane(new StackPane(new Group(pane)));
 		
 		// The call below is necessary to removes the focus highlight around the Canvas
 		// See issue #250
@@ -181,6 +193,30 @@ public class DiagramTab extends Tab implements MouseDraggedGestureHandler, KeyEv
 	public void selectAll()
 	{
 		aDiagramCanvasController.selectAll();
+	}
+	
+	/**
+	 * Zooms in the diagram.
+	 */
+	public void zoomIn()
+	{
+		aScaleProperty.set(aScaleProperty.get() * SCALE_MULTIPLIER);
+	}
+	
+	/**
+	 * Zooms out the diagram.
+	 */
+	public void zoomOut()
+	{
+		aScaleProperty.set(aScaleProperty.get() / SCALE_MULTIPLIER);
+	}
+	
+	/**
+	 * Resets the diagram's zoom to its default value.
+	 */
+	public void resetZoom()
+	{
+		aScaleProperty.set(DEFAULT_SCALE);
 	}
 	
 	/**

--- a/src/ca/mcgill/cs/jetuml/gui/EditorFrame.java
+++ b/src/ca/mcgill/cs/jetuml/gui/EditorFrame.java
@@ -127,7 +127,7 @@ public class EditorFrame extends BorderPane
 		});
 		setOnKeyTyped(e -> 
 		{
-			if( !isWelcomeTabShowing())
+			if( !isWelcomeTabShowing() && !e.isShortcutDown())
 			{
 				getSelectedDiagramTab().keyTyped(e.getCharacter());
 			}
@@ -237,7 +237,10 @@ public class EditorFrame extends BorderPane
 						event -> UserPreferences.instance().setBoolean(BooleanPreference.autoEditNode, 
 								((CheckMenuItem) event.getSource()).isSelected())),
 		
-				factory.createMenuItem("view.diagram_size", false, event -> new DiagramSizeDialog(aMainStage).show())));
+				factory.createMenuItem("view.diagram_size", false, event -> new DiagramSizeDialog(aMainStage).show()),
+				factory.createMenuItem("view.zoom_in", false, event -> getSelectedDiagramTab().zoomIn()),
+				factory.createMenuItem("view.zoom_out", false, event -> getSelectedDiagramTab().zoomOut()),
+				factory.createMenuItem("view.reset_zoom", false, event -> getSelectedDiagramTab().resetZoom())));
 	}
 	
 	private void createHelpMenu(MenuBar pMenuBar) 


### PR DESCRIPTION
# Description
- Zooming in/out uses an exponential scale, with a base of 1.25
- Each tab maintains its own independent zoom level
- Allows user to reset zoom using `ctrl + 0`.
  - This required adding a filter on the toolbar selection hotkeys

# Limitations
Although #328 mentions using `ctrl + '+'` to zoom in, I bound it to `ctrl + '='` as I believe this shortcut is much more intuitive. The perfect solution would bind both `ctrl + '+'` and `ctrl + '='` to this function though unfortunately that is not easily achieved using `MenuItem`s.

Icons for the new menu items are missing.