### PR TITLE
#400 Verify and update failing tests

### DIFF
--- a/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
+++ b/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
@@ -243,7 +243,7 @@ public class TestPersistenceService
 		assertTrue(cr2.getStart() == a3);
 		assertTrue(cr2.getEnd() == a1);
 		
-		assertEquals(new Rectangle(osDependent(229,232, 229), 205, osDependent(61,54, 61), 44), getBounds(cr3));
+		assertEquals(new Rectangle(osDependent(229,228, 229), 205, osDependent(61,62, 61), 44), getBounds(cr3));
 		assertTrue( cr3.getStart() == a3);
 		assertTrue( cr3.getEnd() == a2);
 		assertTrue( cr3.properties().get("Dependency Type").get() == UseCaseDependencyEdge.Type.Extend);
@@ -264,7 +264,7 @@ public class TestPersistenceService
 		assertTrue( cr7.getStart() == u2 );
 		assertTrue( cr7.getEnd() == u1 );
 
-		assertEquals(new Rectangle(osDependent(484,487, 484),169,osDependent(63,56, 62),62), getBounds(cr8));
+		assertEquals(new Rectangle(osDependent(484,483, 484),169,osDependent(63,64, 62),62), getBounds(cr8));
 		assertTrue( cr8.getStart() == u2 );
 		assertTrue( cr8.getEnd() == u3 );
 		assertTrue( cr8.properties().get("Dependency Type").get() == UseCaseDependencyEdge.Type.Include);
@@ -446,7 +446,7 @@ public class TestPersistenceService
 		NoteNode note = (NoteNode) findRootNode(pDiagram, NoteNode.class, build());
 		PointNode point = (PointNode) findRootNode(pDiagram, PointNode.class, build());
 		
-		assertEquals(new Rectangle(160,0,osDependent(98,86, 102),250), NodeViewerRegistry.getBounds(object1));
+		assertEquals(new Rectangle(160,0,osDependent(98,94, 102),250), NodeViewerRegistry.getBounds(object1));
 		List<Node> o1children = object1.getChildren();
 		assertEquals(2, o1children.size());
 		assertEquals("object1:Type1", object1.getName().toString());
@@ -465,11 +465,11 @@ public class TestPersistenceService
 		assertEquals("object3:", object3.getName().toString());
 		CallNode o3Call = (CallNode) o3children.get(0);
 		
-		assertEquals(new Rectangle(osDependent(201,195, 203),80,16,150), NodeViewerRegistry.getBounds(init));
+		assertEquals(new Rectangle(osDependent(201,199, 203),80,16,150), NodeViewerRegistry.getBounds(init));
 		assertEquals(object1, init.getParent());
 		assertFalse(init.isOpenBottom());
 		
-		assertEquals(new Rectangle(osDependent(209,203, 211),100,16,110), NodeViewerRegistry.getBounds(selfCall));
+		assertEquals(new Rectangle(osDependent(209,207, 211),100,16,110), NodeViewerRegistry.getBounds(selfCall));
 		assertEquals(object1, selfCall.getParent());
 		assertFalse(selfCall.isOpenBottom());
 		
@@ -496,13 +496,13 @@ public class TestPersistenceService
 		ReturnEdge retC = (ReturnEdge) eIterator.next(); 
 		NoteEdge nedge = (NoteEdge) eIterator.next(); 
 		
-		assertEquals(new Rectangle(osDependent(214,208, 216), 85, osDependent(84, 76, 84), osDependent(25,24, 25)), getBounds(self));
+		assertEquals(new Rectangle(osDependent(214,212, 216), 85, 84, 25), getBounds(self));
 		assertEquals(selfCall, self.getEnd());
 		assertEquals("selfCall()", self.getMiddleLabel());
 		assertEquals(init, self.getStart());
 		assertFalse(self.isSignal());
 		
-		assertEquals(new Rectangle(osDependent(224,218, 226), 100, osDependent(179, 185, 177), 
+		assertEquals(new Rectangle(osDependent(224,222, 226), 100, osDependent(179, 181, 177), 
 				osDependent(26,25, 26)), getBounds(signal));
 		assertEquals(o2Call, signal.getEnd());
 		assertEquals("signal", signal.getMiddleLabel());
@@ -520,7 +520,7 @@ public class TestPersistenceService
 		assertEquals("r1", ret1.getMiddleLabel());
 		assertEquals(o3Call, ret1.getStart());
 		
-		assertEquals(new Rectangle(osDependent(223,217, 225), 183, osDependent(180,186, 178), 12), getBounds(retC));
+		assertEquals(new Rectangle(osDependent(223,221, 225), 183, osDependent(180,182, 178), 12), getBounds(retC));
 		assertEquals(selfCall, retC.getEnd());
 		assertEquals("", retC.getMiddleLabel());
 		assertEquals(o2Call, retC.getStart());
@@ -556,7 +556,7 @@ public class TestPersistenceService
 		assertEquals(new Rectangle(640, 230, 20, 20), NodeViewerRegistry.getBounds(end));
 		
 		assertEquals("A note\non two lines", note.getName());
-		assertEquals(new Rectangle(690, 320, osDependent(86,73, 86), 40), NodeViewerRegistry.getBounds(note));
+		assertEquals(new Rectangle(690, 320, osDependent(86,81, 86), 40), NodeViewerRegistry.getBounds(note));
 		
 		assertEquals(new Rectangle(576, 339, 0, 0), NodeViewerRegistry.getBounds(point));
 		
@@ -580,7 +580,7 @@ public class TestPersistenceService
 		assertEquals(s1, fromStart.getEnd());
 		assertEquals("start", fromStart.getMiddleLabel().toString());
 		
-		assertEquals(new Rectangle(328, osDependent(100,100, 101), 182, osDependent(28,27, 26)), getBounds(e1));
+		assertEquals(new Rectangle(328, osDependent(100,101, 101), 182, osDependent(28,27, 26)), getBounds(e1));
 		assertEquals(s1, e1.getStart());
 		assertEquals(s2, e1.getEnd());
 		assertEquals("e1", e1.getMiddleLabel().toString());
@@ -624,12 +624,12 @@ public class TestPersistenceService
 		assertEquals(":Type1", type1.getName().toString());
 		
 		FieldNode name = (FieldNode) children.get(0);
-		assertEquals(new Rectangle(245, 200, osDependent(100, 80, 90), osDependent(20, 20, 21)), NodeViewerRegistry.getBounds(name));
+		assertEquals(new Rectangle(245, 200, osDependent(100, 100, 90), osDependent(20, 20, 21)), NodeViewerRegistry.getBounds(name));
 		assertEquals("name", name.getName().toString());
 		assertEquals(type1, name.getParent());
 		assertEquals("", name.getValue().toString());
 
-		assertEquals(new Rectangle(440, 290, osDependent(120, 100, 110), 150), NodeViewerRegistry.getBounds(blank));
+		assertEquals(new Rectangle(440, 290, osDependent(120, 120, 110), 150), NodeViewerRegistry.getBounds(blank));
 		children = blank.getChildren();
 		assertEquals(3, children.size());
 		assertEquals("", blank.getName().toString());
@@ -637,17 +637,17 @@ public class TestPersistenceService
 		FieldNode name3 = (FieldNode) children.get(1);
 		FieldNode name4 = (FieldNode) children.get(2);
 		
-		assertEquals(new Rectangle(445, 360, osDependent(110, 90, 100), 23), NodeViewerRegistry.getBounds(name2));
+		assertEquals(new Rectangle(445, 360, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name2));
 		assertEquals("name2", name2.getName().toString());
 		assertEquals(blank, name2.getParent());
 		assertEquals("value", name2.getValue().toString());
 		
-		assertEquals(new Rectangle(445, 388, osDependent(110, 90, 100), 23), NodeViewerRegistry.getBounds(name3));
+		assertEquals(new Rectangle(445, 388, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name3));
 		assertEquals("name3", name3.getName().toString());
 		assertEquals(blank, name3.getParent());
 		assertEquals("value", name3.getValue().toString());
 		
-		assertEquals(new Rectangle(445, 416, osDependent(110, 90, 100), 23), NodeViewerRegistry.getBounds(name4));
+		assertEquals(new Rectangle(445, 416, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name4));
 		assertEquals("name4", name4.getName().toString());
 		assertEquals(blank, name4.getParent());
 		assertEquals("", name4.getValue().toString());
@@ -678,20 +678,20 @@ public class TestPersistenceService
 		NoteEdge ne2 = (NoteEdge) eIt.next();
 		ObjectCollaborationEdge cr1 = (ObjectCollaborationEdge) eIt.next();
 		
-		assertEquals(new Rectangle(osDependent(339, 319, 329), osDependent(174, 174, 179), 32, osDependent(37, 37, 32)), getBounds(o1));
+		assertEquals(new Rectangle(osDependent(339, 339, 329), osDependent(174, 174, 179), 32, osDependent(37, 37, 32)), getBounds(o1));
 		assertEquals(name, o1.getStart());
 		assertEquals(type1, o1.getEnd());
 		
-		assertEquals(new Rectangle(osDependent(339, 319, 329), 209, osDependent(102, 122, 112), 157), getBounds(o2));
+		assertEquals(new Rectangle(osDependent(339, 339, 329), 209, osDependent(102, 102, 112), 157), getBounds(o2));
 		assertEquals(name, o2.getStart());
 		assertEquals(blank, o2.getEnd());
 		
-		assertEquals(new Rectangle(osDependent(530, 524, 527), 208, osDependent(37, 41, 39), 82), getBounds(cr1));
+		assertEquals(new Rectangle(osDependent(530, 530, 527), 208, osDependent(37, 37, 39), 82), getBounds(cr1));
 		assertEquals(object2, cr1.getEnd());
 		assertEquals("e1", cr1.getMiddleLabel().toString());
 		assertEquals(blank, cr1.getStart());
 		
-		assertEquals(new Rectangle(osDependent(549, 529, 539), 329, osDependent(62, 82, 72), 99), getBounds(o3));
+		assertEquals(new Rectangle(osDependent(549, 549, 539), 329, osDependent(62, 62, 72), 99), getBounds(o3));
 		assertEquals(name4, o3.getStart());
 		assertEquals(type3, o3.getEnd());
 		

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestFieldNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestFieldNodeViewer.java
@@ -70,8 +70,8 @@ public class TestFieldNodeViewer
 	public void testDimensionsUnattachedWithNameString()
 	{
 		aFieldNode1.setName("XXXXX");
-		assertEquals(osDependent(59, 49, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
-		assertEquals(osDependent(40, 35, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
+		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
+		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
 		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
 	}
 	
@@ -79,8 +79,8 @@ public class TestFieldNodeViewer
 	public void testDimensionsUnattachedWithValueString()
 	{
 		aFieldNode1.setValue("XXXXX");
-		assertEquals(osDependent(10, 5, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
-		assertEquals(osDependent(59, 49, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
+		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
+		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
 		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
 	}
 	
@@ -91,7 +91,7 @@ public class TestFieldNodeViewer
 		// y = 0
 		// w = default length (30)/2 + 2* offset (6) = 42
 		// h = default height = 20
-		assertEquals( new Rectangle(osDependent(20, 25, 23),0,osDependent(50, 40, 44),20), NodeViewerRegistry.getBounds(aFieldNode1));
+		assertEquals( new Rectangle(osDependent(20, 20, 23),0,osDependent(50, 50, 44),20), NodeViewerRegistry.getBounds(aFieldNode1));
 	}
 	
 	@Test
@@ -103,7 +103,7 @@ public class TestFieldNodeViewer
 		// y = 0
 		// w = 47 * 2
 		// h = text height 22
-		assertEquals( new Rectangle(osDependent(-29, -19, -23), 0, osDependent(118, 98, 106), osDependent(22, 22, 23)), NodeViewerRegistry.getBounds(aFieldNode1));
+		assertEquals( new Rectangle(osDependent(-29, -32, -23), 0, osDependent(118, 124, 106), osDependent(22, 22, 23)), NodeViewerRegistry.getBounds(aFieldNode1));
 	}
 	
 	@Test
@@ -111,7 +111,7 @@ public class TestFieldNodeViewer
 	{
 		// x = max x of the node bounds - x gap
 		// y = half-point of the default height
-		assertEquals( new Point(osDependent(65, 60, 62),10), NodeViewerRegistry.getConnectionPoints(aFieldNode1, Direction.EAST));
+		assertEquals( new Point(osDependent(65, 65, 62),10), NodeViewerRegistry.getConnectionPoints(aFieldNode1, Direction.EAST));
 	}
 	
 	// NEW
@@ -120,8 +120,8 @@ public class TestFieldNodeViewer
 	public void testDimensionsAttachedNoStrings()
 	{
 		aObjectNode1.addChild(aFieldNode1);
-		assertEquals(osDependent(10, 5, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
-		assertEquals(osDependent(40, 35, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
+		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
+		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
 		assertEquals(20, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
 	}
 	
@@ -130,8 +130,8 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aObjectNode1.setName("XXXXXXXXXXXXXXXXXXX");
-		assertEquals(osDependent(10, 5, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
-		assertEquals(osDependent(40, 35, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
+		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
+		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
 		assertEquals(20, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
 	}
 	
@@ -140,8 +140,8 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aFieldNode1.setName("XXXXX");
-		assertEquals(osDependent(59, 49, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
-		assertEquals(osDependent(40, 35, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
+		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
+		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
 		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
 	}
 	
@@ -150,8 +150,8 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aFieldNode1.setValue("XXXXX");
-		assertEquals(osDependent(10, 5, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
-		assertEquals(osDependent(59, 49, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
+		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
+		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
 		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
 	}
 	

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestObjectNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestObjectNodeViewer.java
@@ -75,7 +75,7 @@ public class TestObjectNodeViewer
 	public void testGetSplitPosition_OneField()
 	{
 		aNode.addChild(aField1);
-		assertEquals(osDependent(15, 10, 12), aViewer.getSplitPosition(aNode));
+		assertEquals(osDependent(15, 15, 12), aViewer.getSplitPosition(aNode));
 	}
 	
 	@Test
@@ -84,7 +84,7 @@ public class TestObjectNodeViewer
 		aNode.addChild(aField1);
 		aNode.addChild(aField2);
 		aField2.setName("XXXXX");
-		assertEquals(osDependent(64, 54, 58), aViewer.getSplitPosition(aNode));
+		assertEquals(osDependent(64, 67, 58), aViewer.getSplitPosition(aNode));
 	}
 	
 	@Test

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestPackageNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestPackageNodeViewer.java
@@ -117,7 +117,7 @@ public class TestPackageNodeViewer
 	public void testGetBoundsNameNoContent()
 	{
 		aPackageNode1.setName("Package");
-		assertEqualRectangles(0,0, osDependent(102,100,101),80, NodeViewerRegistry.getBounds(aPackageNode1));
+		assertEqualRectangles(0,0, osDependent(102,102,101),80, NodeViewerRegistry.getBounds(aPackageNode1));
 	}
 	
 	@Test
@@ -130,7 +130,7 @@ public class TestPackageNodeViewer
 	public void testGetTopBoundsName()
 	{
 		aPackageNode1.setName("Package");
-		assertEqualRectangles(0,0,osDependent(62, 60, 61),20, getTopBounds(aPackageNode1));
+		assertEqualRectangles(0,0,osDependent(62, 62, 61),20, getTopBounds(aPackageNode1));
 	}
 	
 	@Test


### PR DESCRIPTION
Summary of the Changes:
   After the geometryUtil class updates (#399), there were some tests that were not passing on MacOS, mainly the OS-dependent bounds for certain notes; use case dependency edge; implicit parameter nodes, self call edges, and call nodes in sequence diagrams etc. To fix, I went through the tester, and if the change in bound was like 1 pixel, I just changed it. If it was more, I checked the diagram to make sure it rendered properly and if so, I changed it.
   Most of the bound changes actually matched that for Windows, and if not, become significantly closer. The worst case discrepancy went from +- 20 pixels to +- 5 pixels.