### PR TITLE
#402 Save and restore the text alignment when drawing strings

### DIFF
--- a/src/ca/mcgill/cs/jetuml/views/StringViewer.java
+++ b/src/ca/mcgill/cs/jetuml/views/StringViewer.java
@@ -138,6 +138,8 @@ public final class StringViewer
 	public void draw(String pString, GraphicsContext pGraphics, Rectangle pRectangle)
 	{
 		Text label = getLabel(pString);
+		final VPos oldVPos = pGraphics.getTextBaseline();
+		final TextAlignment oldAlign = pGraphics.getTextAlign();
 		
 		pGraphics.setTextAlign(label.getTextAlignment());
 		
@@ -177,5 +179,7 @@ public final class StringViewer
 					(int) (textX-xOffset+bounds.getWidth()), textY+yOffset, LineStyle.SOLID);
 		}
 		pGraphics.translate(-pRectangle.getX(), -pRectangle.getY());
+		pGraphics.setTextBaseline(oldVPos);
+		pGraphics.setTextAlign(oldAlign);
 	}
 }


### PR DESCRIPTION
Summary of changes:
The `StringViewer.draw` method changed the state of the graphics content, which affected other components. These changes (the text alignment) are now restored upon leaving the method.