### PR TITLE
#409 Set text baseline conditioned on if the endpoint is above the start

### DIFF
--- a/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
@@ -107,7 +107,11 @@ public class SegmentedEdgeViewer extends AbstractEdgeViewer
 		{
 			textX = bounds.getWidth()/2;
 			textY = bounds.getHeight() - textDimensions(pString).height()/2;
-			pGraphics.setTextBaseline(VPos.CENTER);
+			pGraphics.setTextBaseline(VPos.BOTTOM);
+			if ( pEndPoint2.getY() > pEndPoint1.getY() ) 
+			{
+				pGraphics.setTextBaseline(VPos.TOP);
+			}
 			pGraphics.setTextAlign(TextAlignment.CENTER);
 		}
 		pGraphics.fillText(pString, textX, textY);


### PR DESCRIPTION
Summary of Changes:
Before, the text was indiscriminately set to center horizontally. However, this didn't take into account if the ending node was above or below the starting endpoint, which, due to how the string's vertical position is calculated, made it not properly centered. This change checks this and sets the baseline appropriately. 