### PR TITLE
413 refactor the string viewer

### DIFF
--- a/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
@@ -29,6 +29,7 @@ import ca.mcgill.cs.jetuml.geom.Line;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+import ca.mcgill.cs.jetuml.views.FontMetrics;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Bounds;
 import javafx.scene.canvas.GraphicsContext;
@@ -36,7 +37,6 @@ import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.Shape;
-import javafx.scene.text.Text;
 
 /**
  * Provides shared services for viewing an edge.
@@ -46,12 +46,7 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	protected static final int MAX_DISTANCE = 3;
 	protected static final int BUTTON_SIZE = 25;
 	protected static final int OFFSET = 3;
-	private static final Text SIZE_TESTER = new Text();
-	
-	static
-	{
-		SIZE_TESTER.setFont(FONT);
-	}
+	private static final FontMetrics SIZE_TESTER = new FontMetrics(FONT);
 	
 	private static final int DEGREES_180 = 180;
 	
@@ -80,9 +75,7 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	 */
 	protected static Dimension textDimensions( String pText )
 	{
-		SIZE_TESTER.setText(pText);
-		Bounds bounds = SIZE_TESTER.getBoundsInLocal();
-		return new Dimension((int)bounds.getWidth(), (int)bounds.getHeight());
+		return SIZE_TESTER.getDimension(pText);
 	}
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
+++ b/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
@@ -82,17 +82,4 @@ public class FontMetrics
 		double leading = aTextNode.getLayoutBounds().getMaxY();
 		return new Dimension((int) bounds.getWidth(), (int) (bounds.getHeight() - leading));
 	}
-
-	/**
-	 * Returns the logical height of the string.
-	 * @param pString The string to use.
-	 * @return The height defined by the ascent, descent, and leading
-	 */
-	public int getLogicalHeight(String pString)
-	{
-		assert pString != null;
-		
-		aTextNode.setText(pString);
-		return (int) aTextNode.getLayoutBounds().getHeight();
-	}
 } 

--- a/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
+++ b/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * JetUML - A desktop application for fast UML diagramming.
+ *
+ * Copyright (C) 2020 by McGill University.
+ *     
+ * See: https://github.com/prmr/JetUML
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *******************************************************************************/
+package ca.mcgill.cs.jetuml.views;
+
+import ca.mcgill.cs.jetuml.geom.Dimension;
+import javafx.geometry.Bounds;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+
+/**
+ * A utility class to determine various font position metrics
+ * for the particular font.
+ * 
+ * A visual diagram for why the bounds values are what they are
+ * (with word "Thy"):   ____________________
+ * getMinY() (ascent)  |*****  *           |
+ *                     |  *    *           |
+ *                     |  *    *****   *  *|
+ *                     |  *    *   *   *  *|
+ *                     |  *    *   *   ****|
+ * (baseline)          |------------------*| x=getWidth()
+ *                     |                  *|
+ *                     |                  *| 
+ * y = 0  (descent)    |                ***|
+ *                     |                   |
+ *                     |                   |
+ * getMaxY() (leading) |-------------------|
+ *
+ * Hence, upon calling getHeight(), to get tight bounds, one should subtract
+ * off the leading value (found by getting the max Y value of a one-lined text
+ * box)
+ */
+public class FontMetrics 
+{
+
+	private static final String BLANK = "";
+	private Text aTextNode;
+
+	/**
+	 * Creates a new FontMetrics object.
+	 * @param pFont The font to use.
+	 */
+
+	public FontMetrics(Font pFont)
+	{
+		assert pFont != null;
+		
+		aTextNode = new Text();
+		aTextNode.setFont(pFont);
+	}
+
+	/**
+	 * Returns the dimension of this string.
+	 * @param pString The string to which the bounds pertain.
+	 * @return The dimension of the string
+	 */
+	public Dimension getDimension(String pString)
+	{
+		assert pString != null;
+		
+		aTextNode.setText(pString);
+		Bounds bounds = aTextNode.getLayoutBounds();
+		aTextNode.setText(BLANK);
+		double leading = aTextNode.getLayoutBounds().getMaxY();
+		return new Dimension((int) bounds.getWidth(), (int) (bounds.getHeight() - leading));
+	}
+
+	/**
+	 * Returns the logical height of the string.
+	 * @param pString The string to use.
+	 * @return The height defined by the ascent, descent, and leading
+	 */
+	public int getLogicalHeight(String pString)
+	{
+		assert pString != null;
+		
+		aTextNode.setText(pString);
+		return (int) aTextNode.getLayoutBounds().getHeight();
+	}
+} 

--- a/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
+++ b/src/ca/mcgill/cs/jetuml/views/FontMetrics.java
@@ -68,7 +68,7 @@ public class FontMetrics
 	}
 
 	/**
-	 * Returns the dimension of this string.
+	 * Returns the dimension of a given string.
 	 * @param pString The string to which the bounds pertain.
 	 * @return The dimension of the string
 	 */
@@ -80,6 +80,6 @@ public class FontMetrics
 		Bounds bounds = aTextNode.getLayoutBounds();
 		aTextNode.setText(BLANK);
 		double leading = aTextNode.getLayoutBounds().getMaxY();
-		return new Dimension((int) bounds.getWidth(), (int) (bounds.getHeight() - leading));
+		return new Dimension((int) Math.round(bounds.getWidth()), (int) Math.round(bounds.getHeight() - leading));
 	}
 } 

--- a/src/ca/mcgill/cs/jetuml/views/StringViewer.java
+++ b/src/ca/mcgill/cs/jetuml/views/StringViewer.java
@@ -22,14 +22,11 @@ package ca.mcgill.cs.jetuml.views;
 
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
-import javafx.geometry.Bounds;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
-import javafx.scene.text.Text;
 import javafx.scene.text.TextAlignment;
-import javafx.scene.text.TextBoundsType;
 
 /**
  * A utility class to view strings with various decorations:
@@ -41,6 +38,8 @@ public final class StringViewer
 {
 	public static final Font FONT = Font.font("System", 12);
 	private static final Font FONT_BOLD = Font.font(FONT.getFamily(), FontWeight.BOLD, FONT.getSize());
+	private static final FontMetrics FONT_METRICS = new FontMetrics(FONT);
+	private static final FontMetrics FONT_BOLD_METRICS = new FontMetrics(FONT_BOLD);
 	
 	private static final Dimension EMPTY = new Dimension(0, 0);
 	private static final int HORIZONTAL_TEXT_PADDING = 7;
@@ -84,6 +83,15 @@ public final class StringViewer
 		}
 	}
 	
+	private FontMetrics getFontMetrics()
+	{
+		if ( aBold )
+		{
+			return FONT_BOLD_METRICS;
+		}
+		return FONT_METRICS;
+	}
+	
 	/**
      * Gets the width and height required to show pString, including
      * padding around the string.
@@ -98,35 +106,22 @@ public final class StringViewer
 		{
 			return EMPTY;
 		}
-		Bounds bounds = getLabel(pString).getLayoutBounds(); 
-		return new Dimension((int) Math.round(bounds.getWidth() + HORIZONTAL_TEXT_PADDING*2), 
-				(int) Math.round(bounds.getHeight() + VERTICAL_TEXT_PADDING*2));
+		Dimension dimension = getFontMetrics().getDimension(pString);
+		return new Dimension((int) Math.round(dimension.width() + HORIZONTAL_TEXT_PADDING*2), 
+				(int) Math.round(dimension.height() + VERTICAL_TEXT_PADDING*2));
 	}
 	
-	private Text getLabel(String pString)
-	{
-		Text label = new Text();
-		if (aUnderlined)
-		{
-			label.setUnderline(true);
-		}
-		label.setFont(getFont());
-		label.setBoundsType(TextBoundsType.VISUAL);
-		label.setText(pString);
-		
+	private TextAlignment getTextAlignment()
+	{		
 		if(aAlignment == Align.LEFT)
 		{
-			label.setTextAlignment(TextAlignment.LEFT);
+			return TextAlignment.LEFT;
 		}
 		else if(aAlignment == Align.CENTER)
 		{
-			label.setTextAlignment(TextAlignment.CENTER);
+			return TextAlignment.CENTER;
 		}
-		else if(aAlignment == Align.RIGHT) 
-		{
-			label.setTextAlignment(TextAlignment.RIGHT);
-		}
-		return label;
+		return TextAlignment.RIGHT;
 	}
 	
 	/**
@@ -137,11 +132,10 @@ public final class StringViewer
 	 */
 	public void draw(String pString, GraphicsContext pGraphics, Rectangle pRectangle)
 	{
-		Text label = getLabel(pString);
 		final VPos oldVPos = pGraphics.getTextBaseline();
 		final TextAlignment oldAlign = pGraphics.getTextAlign();
 		
-		pGraphics.setTextAlign(label.getTextAlignment());
+		pGraphics.setTextAlign(getTextAlignment());
 		
 		int textX = 0;
 		int textY = 0;
@@ -164,19 +158,19 @@ public final class StringViewer
 		{
 			int xOffset = 0;
 			int yOffset = 0;
-			Bounds bounds = label.getLayoutBounds();
+			Dimension dimension = getFontMetrics().getDimension(pString);
 			if(aAlignment == Align.CENTER)
 			{
-				xOffset = (int) (bounds.getWidth()/2);
+				xOffset = (int) (dimension.width()/2);
 				yOffset = (int) (getFont().getSize()/2) + 1;
 			}
 			else if(aAlignment == Align.RIGHT)
 			{
-				xOffset = (int) bounds.getWidth();
+				xOffset = (int) dimension.width();
 			}
 			
 			ViewUtils.drawLine(pGraphics, textX-xOffset, textY+yOffset, 
-					(int) (textX-xOffset+bounds.getWidth()), textY+yOffset, LineStyle.SOLID);
+					(int) (textX-xOffset+dimension.width()), textY+yOffset, LineStyle.SOLID);
 		}
 		pGraphics.translate(-pRectangle.getX(), -pRectangle.getY());
 		pGraphics.setTextBaseline(oldVPos);

--- a/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
+++ b/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
@@ -204,10 +204,10 @@ public class TestPersistenceService
 		assertEquals(new Rectangle(460, 230, 110, 40), NodeViewerRegistry.getBounds(u3));
 		assertEquals("Use case 3", u3.getName().toString());
 		
-		assertTrue(new Rectangle(270, 50, 48, 88).equals(NodeViewerRegistry.getBounds(a1)) || new Rectangle(270, 50, 48, 87).equals(NodeViewerRegistry.getBounds(a1)));
+		assertTrue(new Rectangle(270, 50, 48, 89).equals(NodeViewerRegistry.getBounds(a1)) || new Rectangle(270, 50, 48, 87).equals(NodeViewerRegistry.getBounds(a1)));
 		assertEquals("Actor", a1.getName().toString());
 		
-		assertTrue(new Rectangle(280, 230, 48, 88).equals(NodeViewerRegistry.getBounds(a2)) || new Rectangle(280, 230, 48, 87).equals(NodeViewerRegistry.getBounds(a2)));
+		assertTrue(new Rectangle(280, 230, 48, 89).equals(NodeViewerRegistry.getBounds(a2)) || new Rectangle(280, 230, 48, 87).equals(NodeViewerRegistry.getBounds(a2)));
 		assertEquals("Actor2", a2.getName().toString());
 		
 		assertEquals("A note", n1.getName());
@@ -218,7 +218,7 @@ public class TestPersistenceService
 		assertEquals(new Rectangle(650, 150, 110, 40), NodeViewerRegistry.getBounds(u4));
 		assertEquals("Use case 4", u4.getName().toString());
 		
-		assertTrue(new Rectangle(190, 140, 48, 88).equals(NodeViewerRegistry.getBounds(a3)) || new Rectangle(190, 140, 48, 87).equals(NodeViewerRegistry.getBounds(a3)));
+		assertTrue(new Rectangle(190, 140, 48, 89).equals(NodeViewerRegistry.getBounds(a3)) || new Rectangle(190, 140, 48, 87).equals(NodeViewerRegistry.getBounds(a3)));
 		assertEquals("Actor3", a3.getName().toString());
 		
 		assertEquals(10,  numberOfEdges(pDiagram));
@@ -239,24 +239,24 @@ public class TestPersistenceService
 		assertTrue(cr1.getStart() == n1);
 		assertTrue(cr1.getEnd() == p1);
 		
-		assertEquals(new Rectangle(236, 118, 34, 38), getBounds(cr2));
+		assertEquals(new Rectangle(236, 119, 34, 38), getBounds(cr2));
 		assertTrue(cr2.getStart() == a3);
 		assertTrue(cr2.getEnd() == a1);
 		
-		assertEquals(new Rectangle(osDependent(229,228, 229), 205, osDependent(61,62, 61), 44), getBounds(cr3));
+		assertEquals(new Rectangle(osDependent(229,228, 229), 206, osDependent(61,63, 61), 44), getBounds(cr3));
 		assertTrue( cr3.getStart() == a3);
 		assertTrue( cr3.getEnd() == a2);
 		assertTrue( cr3.properties().get("Dependency Type").get() == UseCaseDependencyEdge.Type.Extend);
 		
-		assertEquals(new Rectangle(316, 61, 125, 28), getBounds(cr4));
+		assertEquals(new Rectangle(316, 61, 125, 29), getBounds(cr4));
 		assertTrue( cr4.getStart() == a1 );
 		assertTrue( cr4.getEnd() == u1 );
 		
-		assertEquals(new Rectangle(326, 158, 141, 101), getBounds(cr5));
+		assertEquals(new Rectangle(326, 158, 141, 102), getBounds(cr5));
 		assertTrue( cr5.getStart() == a2 );
 		assertTrue( cr5.getEnd() == u2 );
 		
-		assertEquals(new Rectangle(326, 250, 134, 20), getBounds(cr6));
+		assertEquals(new Rectangle(326, 250, 134, 21), getBounds(cr6));
 		assertTrue( cr6.getStart() == a2 );
 		assertTrue( cr6.getEnd() == u3 );
 		
@@ -264,12 +264,12 @@ public class TestPersistenceService
 		assertTrue( cr7.getStart() == u2 );
 		assertTrue( cr7.getEnd() == u1 );
 
-		assertEquals(new Rectangle(osDependent(484,483, 484),169,osDependent(63,64, 62),62), getBounds(cr8));
+		assertEquals(new Rectangle(osDependent(484,483, 484),169,osDependent(63,65, 62),62), getBounds(cr8));
 		assertTrue( cr8.getStart() == u2 );
 		assertTrue( cr8.getEnd() == u3 );
 		assertTrue( cr8.properties().get("Dependency Type").get() == UseCaseDependencyEdge.Type.Include);
 		
-		assertEquals(new Rectangle(568,150,82,23), getBounds(cr9));
+		assertEquals(new Rectangle(568,150,82,25), getBounds(cr9));
 		assertTrue( cr9.getStart() == u2 );
 		assertTrue( cr9.getEnd() == u4 );
 		assertTrue( cr9.properties().get("Dependency Type").get() == UseCaseDependencyEdge.Type.Extend);
@@ -370,7 +370,7 @@ public class TestPersistenceService
 		assertEquals("bar", node3.getMethods());
 		assertEquals("Class2", node3.getName());
 		assertFalse(node3.hasParent());
-		assertEquals(new Rectangle(460, 520, 100, 69), NodeViewerRegistry.getBounds(node3));
+		assertEquals(new Rectangle(460, 520, 100, 75), NodeViewerRegistry.getBounds(node3));
 		
 		assertEquals("", node4.getAttributes());
 		assertEquals("", node4.getMethods());
@@ -404,7 +404,7 @@ public class TestPersistenceService
 		assertEquals(node8, edge5.getEnd());
 		
 		DependencyEdge edge6 = (DependencyEdge) eIterator.next();
-		assertEquals(new Rectangle(378, osDependent(390,390, 384), 83, osDependent(23,23, 21)), getBounds(edge6));
+		assertEquals(new Rectangle(378, osDependent(390,390, 384), 83, osDependent(23,25, 21)), getBounds(edge6));
 		assertEquals(node7, edge6.getEnd());
 		assertEquals("e1", edge6.getMiddleLabel());
 		assertEquals(node1, edge6.getStart());
@@ -420,7 +420,7 @@ public class TestPersistenceService
 		assertEquals(node3, edge2.getStart());
 		
 		AggregationEdge edge3 = (AggregationEdge) eIterator.next();
-		assertEquals(new Rectangle(558, osDependent(377,378, 379), 72, osDependent(23,22, 21)), getBounds(edge3));
+		assertEquals(new Rectangle(558, osDependent(377,381, 379), 72, osDependent(23,19, 21)), getBounds(edge3));
 		assertEquals(node4, edge3.getEnd());
 		assertEquals("*", edge3.getEndLabel());
 		assertEquals("e4", edge3.getMiddleLabel());
@@ -428,7 +428,7 @@ public class TestPersistenceService
 		assertEquals("1", edge3.getStartLabel());
 		
 		AggregationEdge edge4 = (AggregationEdge) eIterator.next();
-		assertEquals(new Rectangle(559, 399, 72, 155), getBounds(edge4));
+		assertEquals(new Rectangle(559, 399, 72, 158), getBounds(edge4));
 		assertEquals(node3, edge4.getEnd());
 		assertEquals("", edge4.getEndLabel());
 		assertEquals("e5", edge4.getMiddleLabel());
@@ -496,7 +496,7 @@ public class TestPersistenceService
 		ReturnEdge retC = (ReturnEdge) eIterator.next(); 
 		NoteEdge nedge = (NoteEdge) eIterator.next(); 
 		
-		assertEquals(new Rectangle(osDependent(214,212, 216), 85, 84, 25), getBounds(self));
+		assertEquals(new Rectangle(osDependent(214,212, 216), 85, 85, 25), getBounds(self));
 		assertEquals(selfCall, self.getEnd());
 		assertEquals("selfCall()", self.getMiddleLabel());
 		assertEquals(init, self.getStart());
@@ -515,7 +515,7 @@ public class TestPersistenceService
 		assertEquals(o2Call, call1.getStart());
 		assertFalse(call1.isSignal());
 		
-		assertEquals(new Rectangle(416, 160, 207, osDependent(23,22, 23)), getBounds(ret1));
+		assertEquals(new Rectangle(416, 160, 207, osDependent(23,25, 23)), getBounds(ret1));
 		assertEquals(o2Call, ret1.getEnd());
 		assertEquals("r1", ret1.getMiddleLabel());
 		assertEquals(o3Call, ret1.getStart());
@@ -575,17 +575,17 @@ public class TestPersistenceService
 		assertEquals(note, ne.getStart());
 		assertEquals(point, ne.getEnd());
 		
-		assertEquals(new Rectangle(168, osDependent(73,74, 75), 82, osDependent(37,36, 35)), getBounds(fromStart));
+		assertEquals(new Rectangle(168, osDependent(73,77, 75), 82, osDependent(37,33, 35)), getBounds(fromStart));
 		assertEquals(start, fromStart.getStart());
 		assertEquals(s1, fromStart.getEnd());
 		assertEquals("start", fromStart.getMiddleLabel().toString());
 		
-		assertEquals(new Rectangle(328, osDependent(100,101, 101), 182, osDependent(28,27, 26)), getBounds(e1));
+		assertEquals(new Rectangle(328, osDependent(100,104, 101), 182, osDependent(28,24, 26)), getBounds(e1));
 		assertEquals(s1, e1.getStart());
 		assertEquals(s2, e1.getEnd());
 		assertEquals("e1", e1.getMiddleLabel().toString());
 		
-		assertEquals(new Rectangle(328, 131, 182, osDependent(27,26, 25)), getBounds(e2));
+		assertEquals(new Rectangle(328, 131, 182, osDependent(27,23, 25)), getBounds(e2));
 		assertEquals(s2, e2.getStart());
 		assertEquals(s1, e2.getEnd());
 		assertEquals("e2", e2.getMiddleLabel().toString());
@@ -618,18 +618,18 @@ public class TestPersistenceService
 		PointNode p1 = (PointNode) findRootNode(pDiagram, PointNode.class, build("x", 281));
 		PointNode p2 = (PointNode) findRootNode(pDiagram, PointNode.class, build("x", 474));
 		
-		assertEquals(new Rectangle(240, 130, osDependent(110, 110, 100), osDependent(90, 90, 100)), NodeViewerRegistry.getBounds(type1));
+		assertEquals(new Rectangle(240, 130, osDependent(110, 110, 100), osDependent(90, 100, 100)), NodeViewerRegistry.getBounds(type1));
 		List<Node> children = type1.getChildren();
 		assertEquals(1, children.size());
 		assertEquals(":Type1", type1.getName().toString());
 		
 		FieldNode name = (FieldNode) children.get(0);
-		assertEquals(new Rectangle(245, 200, osDependent(100, 100, 90), osDependent(20, 20, 21)), NodeViewerRegistry.getBounds(name));
+		assertEquals(new Rectangle(245, 200, osDependent(100, 100, 90), osDependent(20, 25, 21)), NodeViewerRegistry.getBounds(name));
 		assertEquals("name", name.getName().toString());
 		assertEquals(type1, name.getParent());
 		assertEquals("", name.getValue().toString());
 
-		assertEquals(new Rectangle(440, 290, osDependent(120, 120, 110), 150), NodeViewerRegistry.getBounds(blank));
+		assertEquals(new Rectangle(440, 290, osDependent(120, 130, 110), 160), NodeViewerRegistry.getBounds(blank));
 		children = blank.getChildren();
 		assertEquals(3, children.size());
 		assertEquals("", blank.getName().toString());
@@ -637,17 +637,17 @@ public class TestPersistenceService
 		FieldNode name3 = (FieldNode) children.get(1);
 		FieldNode name4 = (FieldNode) children.get(2);
 		
-		assertEquals(new Rectangle(445, 360, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name2));
+		assertEquals(new Rectangle(445, 360, osDependent(110, 120, 100), 25), NodeViewerRegistry.getBounds(name2));
 		assertEquals("name2", name2.getName().toString());
 		assertEquals(blank, name2.getParent());
 		assertEquals("value", name2.getValue().toString());
 		
-		assertEquals(new Rectangle(445, 388, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name3));
+		assertEquals(new Rectangle(445, 390, osDependent(110, 120, 100), 25), NodeViewerRegistry.getBounds(name3));
 		assertEquals("name3", name3.getName().toString());
 		assertEquals(blank, name3.getParent());
 		assertEquals("value", name3.getValue().toString());
 		
-		assertEquals(new Rectangle(445, 416, osDependent(110, 110, 100), 23), NodeViewerRegistry.getBounds(name4));
+		assertEquals(new Rectangle(445, 420, osDependent(110, 120, 100), 25), NodeViewerRegistry.getBounds(name4));
 		assertEquals("name4", name4.getName().toString());
 		assertEquals(blank, name4.getParent());
 		assertEquals("", name4.getValue().toString());
@@ -678,20 +678,20 @@ public class TestPersistenceService
 		NoteEdge ne2 = (NoteEdge) eIt.next();
 		ObjectCollaborationEdge cr1 = (ObjectCollaborationEdge) eIt.next();
 		
-		assertEquals(new Rectangle(osDependent(339, 339, 329), osDependent(174, 174, 179), 32, osDependent(37, 37, 32)), getBounds(o1));
+		assertEquals(new Rectangle(osDependent(339, 339, 329), osDependent(174, 179, 179), 32, osDependent(37, 34, 32)), getBounds(o1));
 		assertEquals(name, o1.getStart());
 		assertEquals(type1, o1.getEnd());
 		
-		assertEquals(new Rectangle(osDependent(339, 339, 329), 209, osDependent(102, 102, 112), 157), getBounds(o2));
+		assertEquals(new Rectangle(osDependent(339, 339, 329), 211, osDependent(102, 102, 112), 160), getBounds(o2));
 		assertEquals(name, o2.getStart());
 		assertEquals(blank, o2.getEnd());
 		
-		assertEquals(new Rectangle(osDependent(530, 530, 527), 208, osDependent(37, 37, 39), 82), getBounds(cr1));
+		assertEquals(new Rectangle(osDependent(530, 535, 527), 208, osDependent(37, 33, 39), 82), getBounds(cr1));
 		assertEquals(object2, cr1.getEnd());
 		assertEquals("e1", cr1.getMiddleLabel().toString());
 		assertEquals(blank, cr1.getStart());
 		
-		assertEquals(new Rectangle(osDependent(549, 549, 539), 329, osDependent(62, 62, 72), 99), getBounds(o3));
+		assertEquals(new Rectangle(osDependent(549, 559, 539), 329, osDependent(62, 52, 72), 104), getBounds(o3));
 		assertEquals(name4, o3.getStart());
 		assertEquals(type3, o3.getEnd());
 		

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestFieldNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestFieldNodeViewer.java
@@ -70,18 +70,18 @@ public class TestFieldNodeViewer
 	public void testDimensionsUnattachedWithNameString()
 	{
 		aFieldNode1.setName("XXXXX");
-		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
-		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
-		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
+		assertEquals(osDependent(59, 65, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
+		assertEquals(osDependent(40, 43, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
+		assertEquals(osDependent(22, 25, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
 	}
 	
 	@Test
 	public void testDimensionsUnattachedWithValueString()
 	{
 		aFieldNode1.setValue("XXXXX");
-		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
-		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
-		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
+		assertEquals(osDependent(10, 13, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
+		assertEquals(osDependent(59, 65, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
+		assertEquals(osDependent(22, 25, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
 	}
 	
 	@Test
@@ -91,7 +91,7 @@ public class TestFieldNodeViewer
 		// y = 0
 		// w = default length (30)/2 + 2* offset (6) = 42
 		// h = default height = 20
-		assertEquals( new Rectangle(osDependent(20, 20, 23),0,osDependent(50, 50, 44),20), NodeViewerRegistry.getBounds(aFieldNode1));
+		assertEquals( new Rectangle(osDependent(20, 17, 23),0,osDependent(50, 56, 44),25), NodeViewerRegistry.getBounds(aFieldNode1));
 	}
 	
 	@Test
@@ -103,7 +103,7 @@ public class TestFieldNodeViewer
 		// y = 0
 		// w = 47 * 2
 		// h = text height 22
-		assertEquals( new Rectangle(osDependent(-29, -32, -23), 0, osDependent(118, 124, 106), osDependent(22, 22, 23)), NodeViewerRegistry.getBounds(aFieldNode1));
+		assertEquals( new Rectangle(osDependent(-29, -35, -23), 0, osDependent(118, 130, 106), osDependent(22, 25, 23)), NodeViewerRegistry.getBounds(aFieldNode1));
 	}
 	
 	@Test
@@ -111,7 +111,7 @@ public class TestFieldNodeViewer
 	{
 		// x = max x of the node bounds - x gap
 		// y = half-point of the default height
-		assertEquals( new Point(osDependent(65, 65, 62),10), NodeViewerRegistry.getConnectionPoints(aFieldNode1, Direction.EAST));
+		assertEquals( new Point(osDependent(65, 68, 62),12), NodeViewerRegistry.getConnectionPoints(aFieldNode1, Direction.EAST));
 	}
 	
 	// NEW
@@ -120,9 +120,9 @@ public class TestFieldNodeViewer
 	public void testDimensionsAttachedNoStrings()
 	{
 		aObjectNode1.addChild(aFieldNode1);
-		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
-		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
-		assertEquals(20, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
+		assertEquals(osDependent(10, 13, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
+		assertEquals(osDependent(40, 43, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
+		assertEquals(25, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
 	}
 	
 	@Test
@@ -130,9 +130,9 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aObjectNode1.setName("XXXXXXXXXXXXXXXXXXX");
-		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
-		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
-		assertEquals(20, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
+		assertEquals(osDependent(10, 13, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    // Just the length of the mid offset
+		assertEquals(osDependent(40, 43, 37), aFieldNodeViewer.rightWidth(aFieldNode1));  // Half the default width + mid offset.
+		assertEquals(25, aFieldNodeViewer.getHeight(aFieldNode1));   // Default height
 	}
 	
 	@Test
@@ -140,9 +140,9 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aFieldNode1.setName("XXXXX");
-		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
-		assertEquals(osDependent(40, 40, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
-		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
+		assertEquals(osDependent(59, 65, 53), aFieldNodeViewer.leftWidth(aFieldNode1));    // The length of the string
+		assertEquals(osDependent(40, 43, 37), aFieldNodeViewer.rightWidth(aFieldNode1));   // Half the default width + mid offset.
+		assertEquals(osDependent(22, 25, 23), aFieldNodeViewer.getHeight(aFieldNode1));    // The height of the string
 	}
 	
 	@Test
@@ -150,9 +150,9 @@ public class TestFieldNodeViewer
 	{
 		aObjectNode1.addChild(aFieldNode1);
 		aFieldNode1.setValue("XXXXX");
-		assertEquals(osDependent(10, 10, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
-		assertEquals(osDependent(59, 62, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
-		assertEquals(osDependent(22, 22, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
+		assertEquals(osDependent(10, 13, 7), aFieldNodeViewer.leftWidth(aFieldNode1));    	// Just the length of the mid offset
+		assertEquals(osDependent(59, 65, 53), aFieldNodeViewer.rightWidth(aFieldNode1));  	// The length of the string
+		assertEquals(osDependent(22, 25, 23), aFieldNodeViewer.getHeight(aFieldNode1));    	// The height of the string
 	}
 	
 	@Test
@@ -163,7 +163,7 @@ public class TestFieldNodeViewer
 		// y = top node height
 		// w = left + right
 		// h = default height
-		assertEquals( new Rectangle(5,70,70,20), NodeViewerRegistry.getBounds(aFieldNode1));
+		assertEquals( new Rectangle(5,70,70,25), NodeViewerRegistry.getBounds(aFieldNode1));
 	}
 	
 	@AfterEach

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestObjectNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestObjectNodeViewer.java
@@ -75,7 +75,7 @@ public class TestObjectNodeViewer
 	public void testGetSplitPosition_OneField()
 	{
 		aNode.addChild(aField1);
-		assertEquals(osDependent(15, 15, 12), aViewer.getSplitPosition(aNode));
+		assertEquals(osDependent(15, 18, 12), aViewer.getSplitPosition(aNode));
 	}
 	
 	@Test
@@ -84,7 +84,7 @@ public class TestObjectNodeViewer
 		aNode.addChild(aField1);
 		aNode.addChild(aField2);
 		aField2.setName("XXXXX");
-		assertEquals(osDependent(64, 67, 58), aViewer.getSplitPosition(aNode));
+		assertEquals(osDependent(64, 70, 58), aViewer.getSplitPosition(aNode));
 	}
 	
 	@Test
@@ -100,7 +100,7 @@ public class TestObjectNodeViewer
 		aNode.addChild(aField1);
 		aNode.addChild(aField2);
 		assertEquals(70, aViewer.getYPosition(aNode, aField1));
-		assertEquals(95, aViewer.getYPosition(aNode, aField2));
+		assertEquals(100, aViewer.getYPosition(aNode, aField2));
 	}
 	
 	@Test
@@ -137,7 +137,7 @@ public class TestObjectNodeViewer
 		aNode.addChild(aField1);
 		assertEquals(new Point(0,0), aViewer.getBounds(aNode).getOrigin());
 		assertEquals(80, aViewer.getBounds(aNode).getWidth());
-		assertEquals(90, aViewer.getBounds(aNode).getHeight());
+		assertEquals(100, aViewer.getBounds(aNode).getHeight());
 	}
 	
 	@Test
@@ -148,6 +148,6 @@ public class TestObjectNodeViewer
 		aNode.addChild(aField2);
 		assertEquals(new Point(0,0), aViewer.getBounds(aNode).getOrigin());
 		assertEquals(80, aViewer.getBounds(aNode).getWidth());
-		assertEquals(120, aViewer.getBounds(aNode).getHeight());
+		assertEquals(130, aViewer.getBounds(aNode).getHeight());
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestPackageNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestPackageNodeViewer.java
@@ -117,7 +117,7 @@ public class TestPackageNodeViewer
 	public void testGetBoundsNameNoContent()
 	{
 		aPackageNode1.setName("Package");
-		assertEqualRectangles(0,0, osDependent(102,102,101),80, NodeViewerRegistry.getBounds(aPackageNode1));
+		assertEqualRectangles(0,0, osDependent(102,103,101),80, NodeViewerRegistry.getBounds(aPackageNode1));
 	}
 	
 	@Test
@@ -130,7 +130,7 @@ public class TestPackageNodeViewer
 	public void testGetTopBoundsName()
 	{
 		aPackageNode1.setName("Package");
-		assertEqualRectangles(0,0,osDependent(62, 62, 61),20, getTopBounds(aPackageNode1));
+		assertEqualRectangles(0,0,osDependent(62, 63, 61),20, getTopBounds(aPackageNode1));
 	}
 	
 	@Test

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestTypeNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestTypeNodeViewer.java
@@ -130,7 +130,7 @@ public class TestTypeNodeViewer
 		ClassNode node = new ClassNode();
 		node.setName("NAME1\nNAME2\nNAME3\nNAME4");
 		return Arguments.of(node, 
-				new Rectangle(0, 0, 100, osDependent(70, 65, 65))); // Default width and additional height
+				new Rectangle(0, 0, 100, osDependent(70, 68, 65))); // Default width and additional height
 	}
 
 	// Name is just the interface prototype, one methods

--- a/test/ca/mcgill/cs/jetuml/views/TestFontMetrics.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestFontMetrics.java
@@ -1,0 +1,54 @@
+package ca.mcgill.cs.jetuml.views;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.stream.Stream;
+
+import static ca.mcgill.cs.jetuml.views.StringViewer.FONT;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import ca.mcgill.cs.jetuml.geom.Dimension;
+
+public class TestFontMetrics {
+
+	private static final FontMetrics aMetrics = new FontMetrics(FONT);
+	// Ensures there is no caching of sorts when reusing the same Text object
+	@ParameterizedTest
+	@MethodSource("stringPairParameters")
+	public void testStateNotPreserved(String firstString, String secondString)
+	{
+		
+		assertNotEquals(aMetrics.getDimension(firstString), aMetrics.getDimension(secondString));
+	}
+	
+	private static Stream<Arguments> stringPairParameters() {
+	    return Stream.of(
+	            Arguments.of("X", "XX"),
+	            Arguments.of("XX", "XXX"),
+	            Arguments.of("XXX", "XXXX"),
+	            Arguments.of("XXXX", "XXXXX"),
+	            Arguments.of("XXXXX", "XXXXXX")
+	    );
+	}
+	
+	@Test
+	public void testGetDimensions()
+	{
+		assertEquals(new Dimension(0, 11), aMetrics.getDimension(""));
+		assertEquals(new Dimension(92, 11), aMetrics.getDimension("Single-Line-String"));
+		assertEquals(new Dimension(29, 39), aMetrics.getDimension("Multi\nLine\nString"));
+	}
+	
+	@Test
+	public void testGetLogicalHeight()
+	{
+		assertEquals(14, aMetrics.getLogicalHeight(""));
+		assertEquals(14, aMetrics.getLogicalHeight("Single-Line-String"));
+		assertEquals(42, aMetrics.getLogicalHeight("Multi\nLine\nString"));
+	}
+}

--- a/test/ca/mcgill/cs/jetuml/views/TestFontMetrics.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestFontMetrics.java
@@ -43,12 +43,4 @@ public class TestFontMetrics {
 		assertEquals(new Dimension(92, 11), aMetrics.getDimension("Single-Line-String"));
 		assertEquals(new Dimension(29, 39), aMetrics.getDimension("Multi\nLine\nString"));
 	}
-	
-	@Test
-	public void testGetLogicalHeight()
-	{
-		assertEquals(14, aMetrics.getLogicalHeight(""));
-		assertEquals(14, aMetrics.getLogicalHeight("Single-Line-String"));
-		assertEquals(42, aMetrics.getLogicalHeight("Multi\nLine\nString"));
-	}
 }


### PR DESCRIPTION
Summary of the changes:

- Made a class that represents the font metrics for a particular font. It can take in a string, and then output the dimensions of the string, taking into account any potential leading or ascent that may arise. This dimension is tight with respect to these values.
- Changed classes (`StringViewer` and `AbstractEdgeViewer`) that rely on text dimensions directly to utilize this class, rather than doing the calculations themselves.
- Fix tests that were made broken by the change in how precisely the dimensions are determined (notably, it takes into account any _potential_ ascent or descent, as opposed to the old version which only accounted for it if it was there, and making the bounds tighter
- Added a test for the new class that tests both that the dimension calculated is correct and that there is no potential state saving upon testing different strings.