### PR TITLE
#416 Fix failing tests for Mac

### DIFF
--- a/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
+++ b/test/ca/mcgill/cs/jetuml/persistence/TestPersistenceService.java
@@ -204,10 +204,10 @@ public class TestPersistenceService
 		assertEquals(new Rectangle(460, 230, 110, 40), NodeViewerRegistry.getBounds(u3));
 		assertEquals("Use case 3", u3.getName().toString());
 		
-		assertEquals(new Rectangle(270, 50, 48, osDependent(91, 87, 87)), NodeViewerRegistry.getBounds(a1));
+		assertEquals(new Rectangle(270, 50, 48, osDependent(91, 90, 87)), NodeViewerRegistry.getBounds(a1));
 		assertEquals("Actor", a1.getName().toString());
 		
-		assertEquals(new Rectangle(280, 230, 49, 91), NodeViewerRegistry.getBounds(a2));
+		assertEquals(new Rectangle(280, 230, osDependent(49, 48, 49), osDependent(91, 90, 87)), NodeViewerRegistry.getBounds(a2));
 		assertEquals("Actor2", a2.getName().toString());
 		
 		assertEquals("A note", n1.getName());


### PR DESCRIPTION
There were tests that were failing on Mac, but not Windows. These tests should now be fixed.

Note: I had to add an `osDependent` call to one of the `assertEquals`. I don't know what the value for people running Linux is, so I just copies values from similar tests.