### PR TITLE
419 actor node labels not centered

### DIFF
--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
@@ -52,18 +52,22 @@ public final class ActorNodeViewer extends AbstractNodeViewer
 	public Rectangle getBounds(Node pNode)
 	{
 		Dimension nameBounds = NAME_VIEWER.getDimension(((ActorNode)pNode).getName());
-		return new Rectangle(pNode.position().getX(), pNode.position().getY(),
-            Math.max(WIDTH, nameBounds.width()), HEIGHT + nameBounds.height());
+		return new Rectangle(
+				pNode.position().getX() + Math.min(0, (WIDTH - nameBounds.width()) / 2), 
+				pNode.position().getY(),
+				Math.max(WIDTH, nameBounds.width()),
+				HEIGHT + nameBounds.height()
+		);
 	}
 
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)
 	{	
 		Rectangle bounds = getBounds(pNode);
-		Dimension nameBox = NAME_VIEWER.getDimension(((ActorNode)pNode).getName());
-		Rectangle namebox = new Rectangle(bounds.getX() + (int)((bounds.getWidth() - nameBox.width()) / 2.0), 
-				bounds.getY() + HEIGHT, nameBox.width(), nameBox.height());
-		NAME_VIEWER.draw(((ActorNode)pNode).getName(), pGraphics, namebox);
+		Dimension nameBounds = NAME_VIEWER.getDimension(((ActorNode)pNode).getName());
+		Rectangle nameBox = new Rectangle(pNode.position().getX() + (WIDTH - nameBounds.width()) / 2, 
+				bounds.getY() + HEIGHT, nameBounds.width(), nameBounds.height());
+		NAME_VIEWER.draw(((ActorNode)pNode).getName(), pGraphics, nameBox);
 		ToolGraphics.strokeSharpPath(pGraphics, createStickManPath(pNode), LineStyle.SOLID);
 	}
 	

--- a/test/ca/mcgill/cs/jetuml/viewers/nodes/TestActorNodeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/nodes/TestActorNodeViewer.java
@@ -69,7 +69,7 @@ public class TestActorNodeViewer
 	public void testGetBounds_LongName()
 	{
 		aNode.setName("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
-		assertEquals(new Point(0,0), aViewer.getBounds(aNode).getOrigin());
+		assertEquals(new Point(-166,0), aViewer.getBounds(aNode).getOrigin());
 		assertTrue(aViewer.getBounds(aNode).getWidth() > 48);
 		assertTrue(aViewer.getBounds(aNode).getHeight() > 64);
 	}


### PR DESCRIPTION
Summary of Changes:
 * Changed the text positioning so that it calculates it based on the default width of the node and the width of the text, rather than the current bounds of the width
 * Changed the bounds to account for this change
 * Fix the one failing test