### PR TITLE
#422 refactor code involving text

### DIFF
--- a/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
@@ -20,7 +20,7 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static ca.mcgill.cs.jetuml.views.StringViewer.FONT;
+import static java.util.EnumSet.noneOf;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -29,7 +29,7 @@ import ca.mcgill.cs.jetuml.geom.Line;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
-import ca.mcgill.cs.jetuml.views.FontMetrics;
+import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Bounds;
 import javafx.scene.canvas.GraphicsContext;
@@ -46,7 +46,8 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	protected static final int MAX_DISTANCE = 3;
 	protected static final int BUTTON_SIZE = 25;
 	protected static final int OFFSET = 3;
-	private static final FontMetrics SIZE_TESTER = new FontMetrics(FONT);
+	private static final StringViewer SIZE_TESTER = StringViewer.get(StringViewer.VerticalAlign.TOP, StringViewer.HorizontalAlign.LEFT, 
+			noneOf(StringViewer.TextDecorations.class));
 	
 	private static final int DEGREES_180 = 180;
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static java.util.EnumSet.noneOf;
-
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Direction;
@@ -30,6 +28,7 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Bounds;
 import javafx.scene.canvas.GraphicsContext;
@@ -46,8 +45,7 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	protected static final int MAX_DISTANCE = 3;
 	protected static final int BUTTON_SIZE = 25;
 	protected static final int OFFSET = 3;
-	private static final StringViewer SIZE_TESTER = StringViewer.get(StringViewer.VerticalAlign.TOP, StringViewer.HorizontalAlign.LEFT, 
-			noneOf(StringViewer.TextDecorations.class));
+	private static final StringViewer SIZE_TESTER = StringViewer.get(Alignment.TOP_LEFT);
 	
 	private static final int DEGREES_180 = 180;
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
+import static java.util.EnumSet.of;
+
 import java.util.ArrayList;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -53,8 +55,10 @@ import javafx.scene.shape.Shape;
  */
 public final class CallEdgeViewer extends AbstractEdgeViewer
 {	
-	private static final StringViewer CENTERED_STRING_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
-	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
+	private static final StringViewer CENTERED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
 
 	private static final int SHIFT = -10;
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/CallEdgeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static java.util.EnumSet.of;
-
 import java.util.ArrayList;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -40,6 +38,8 @@ import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.ArrowHeadView;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
@@ -55,10 +55,8 @@ import javafx.scene.shape.Shape;
  */
 public final class CallEdgeViewer extends AbstractEdgeViewer
 {	
-	private static final StringViewer CENTERED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
-	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer CENTERED_STRING_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
+	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 
 	private static final int SHIFT = -10;
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
+import static java.util.EnumSet.of;
+
 import java.util.function.Function;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -36,7 +38,8 @@ import javafx.scene.canvas.GraphicsContext;
  */
 public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 {	
-	private static final StringViewer STRING_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
+	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
 	private static final int SHIFT = -10;
 	
 	private final Function<Edge, String> aLabelExtractor;

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static java.util.EnumSet.of;
-
 import java.util.function.Function;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -31,6 +29,8 @@ import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.GraphicsContext;
 
 /**
@@ -38,8 +38,7 @@ import javafx.scene.canvas.GraphicsContext;
  */
 public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 {	
-	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer STRING_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
 	private static final int SHIFT = -10;
 	
 	private final Function<Edge, String> aLabelExtractor;

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static java.util.EnumSet.of;
-
 import java.util.function.Function;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -33,6 +31,7 @@ import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
@@ -48,12 +47,9 @@ import javafx.scene.shape.Shape;
  */
 public class SegmentedEdgeViewer extends AbstractEdgeViewer
 {
-	private static final StringViewer CENTERED_TOP_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
-	private static final StringViewer CENTERED_BOTTOM_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.BOTTOM, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
-	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer TOP_CENTERED_STRING_VIEWER = StringViewer.get(Alignment.TOP_CENTER);
+	private static final StringViewer BOTTOM_CENTERED_STRING_VIEWER = StringViewer.get(Alignment.BOTTOM_CENTER);
+	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(Alignment.TOP_LEFT);
 			
 	private Function<Edge, LineStyle> aLineStyleExtractor;
 	private Function<Edge, ArrowHead> aArrowStartExtractor;
@@ -103,13 +99,13 @@ public class SegmentedEdgeViewer extends AbstractEdgeViewer
 		Rectangle bounds = getStringBounds(pEndPoint1, pEndPoint2, pArrowHead, pString, pCenter);
 		if(pCenter) 
 		{
-			if ( pEndPoint2.getY() > pEndPoint1.getY() )
+			if ( pEndPoint2.getY() >= pEndPoint1.getY() )
 			{
-				CENTERED_TOP_STRING_VIEWER.draw(pString, pGraphics, bounds);
+				TOP_CENTERED_STRING_VIEWER.draw(pString, pGraphics, bounds);
 			}
 			else
 			{
-				CENTERED_BOTTOM_STRING_VIEWER.draw(pString, pGraphics, bounds);
+				BOTTOM_CENTERED_STRING_VIEWER.draw(pString, pGraphics, bounds);
 			}
 		}
 		else

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
+import static java.util.EnumSet.of;
+
 import java.util.function.Function;
 
 import ca.mcgill.cs.jetuml.diagram.Edge;
@@ -30,25 +32,29 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
+import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
-import javafx.geometry.VPos;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.Shape;
-import javafx.scene.text.TextAlignment;
 
 /**
  * Renders edges as a path consisting of straight line segments.
  */
 public class SegmentedEdgeViewer extends AbstractEdgeViewer
 {
+	private static final StringViewer CENTERED_TOP_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer CENTERED_BOTTOM_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.BOTTOM, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+			
 	private Function<Edge, LineStyle> aLineStyleExtractor;
 	private Function<Edge, ArrowHead> aArrowStartExtractor;
 	private Function<Edge, ArrowHead> aArrowEndExtractor;
@@ -95,30 +101,21 @@ public class SegmentedEdgeViewer extends AbstractEdgeViewer
 			return;
 		}
 		Rectangle bounds = getStringBounds(pEndPoint1, pEndPoint2, pArrowHead, pString, pCenter);
-		
-		Paint oldFill = pGraphics.getFill();
-		VPos oldVPos = pGraphics.getTextBaseline();
-		TextAlignment oldAlign = pGraphics.getTextAlign();
-		pGraphics.translate(bounds.getX(), bounds.getY());
-		pGraphics.setFill(Color.BLACK);
-		int textX = 0;
-		int textY = 0;
 		if(pCenter) 
 		{
-			textX = bounds.getWidth()/2;
-			textY = bounds.getHeight() - textDimensions(pString).height()/2;
-			pGraphics.setTextBaseline(VPos.BOTTOM);
-			if ( pEndPoint2.getY() > pEndPoint1.getY() ) 
+			if ( pEndPoint2.getY() > pEndPoint1.getY() )
 			{
-				pGraphics.setTextBaseline(VPos.TOP);
+				CENTERED_TOP_STRING_VIEWER.draw(pString, pGraphics, bounds);
 			}
-			pGraphics.setTextAlign(TextAlignment.CENTER);
+			else
+			{
+				CENTERED_BOTTOM_STRING_VIEWER.draw(pString, pGraphics, bounds);
+			}
 		}
-		pGraphics.fillText(pString, textX, textY);
-		pGraphics.translate(-bounds.getX(), -bounds.getY()); 
-		pGraphics.setFill(oldFill);
-		pGraphics.setTextBaseline(oldVPos);
-		pGraphics.setTextAlign(oldAlign);
+		else
+		{
+			LEFT_JUSTIFIED_STRING_VIEWER.draw(pString, pGraphics, bounds);
+		}
 	}
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
@@ -22,8 +22,6 @@ package ca.mcgill.cs.jetuml.viewers.edges;
 
 import static ca.mcgill.cs.jetuml.views.StringViewer.FONT;
 
-import static java.util.EnumSet.noneOf;
-
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.edges.StateTransitionEdge;
 import ca.mcgill.cs.jetuml.geom.Conversions;
@@ -37,6 +35,7 @@ import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.canvas.Canvas;
@@ -66,8 +65,7 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	private static final double HEIGHT_RATIO = 3.5;
 	private static final int MAX_LENGTH_FOR_NORMAL_FONT = 15;
 	private static final int MIN_FONT_SIZE = 9;
-	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.BOTTOM, StringViewer.HorizontalAlign.CENTER, 
-			noneOf(StringViewer.TextDecorations.class));
+	private static final StringViewer STRING_VIEWER = StringViewer.get(Alignment.CENTER_CENTER);
 	
 	// The amount of vertical difference in connection points to tolerate
 	// before centering the edge label on one side instead of in the center.

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
@@ -22,6 +22,8 @@ package ca.mcgill.cs.jetuml.viewers.edges;
 
 import static ca.mcgill.cs.jetuml.views.StringViewer.FONT;
 
+import static java.util.EnumSet.noneOf;
+
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.edges.StateTransitionEdge;
 import ca.mcgill.cs.jetuml.geom.Conversions;
@@ -33,13 +35,13 @@ import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
+import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
 import javafx.scene.shape.Arc;
 import javafx.scene.shape.ArcType;
 import javafx.scene.shape.MoveTo;
@@ -47,7 +49,6 @@ import javafx.scene.shape.Path;
 import javafx.scene.shape.QuadCurveTo;
 import javafx.scene.shape.Shape;
 import javafx.scene.text.Font;
-import javafx.scene.text.TextAlignment;
 
 /**
  * An edge view specialized for state transitions.
@@ -65,6 +66,8 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	private static final double HEIGHT_RATIO = 3.5;
 	private static final int MAX_LENGTH_FOR_NORMAL_FONT = 15;
 	private static final int MIN_FONT_SIZE = 9;
+	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.BOTTOM, StringViewer.HorizontalAlign.CENTER, 
+			noneOf(StringViewer.TextDecorations.class));
 	
 	// The amount of vertical difference in connection points to tolerate
 	// before centering the edge label on one side instead of in the center.
@@ -118,19 +121,13 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	{
 		adjustLabelFont(pEdge);
 		Rectangle2D labelBounds = getLabelBounds(pEdge);
-		double x = labelBounds.getMinX();
-		double y = labelBounds.getMinY();
+		Rectangle drawingRectangle = new Rectangle((int) Math.round(labelBounds.getMinX()), (int) Math.round(labelBounds.getMinY()), 
+				(int) Math.round(labelBounds.getWidth()), (int) Math.round(labelBounds.getHeight()));
 		
-		Paint oldFill = pGraphics.getFill();
 		Font oldFont = pGraphics.getFont();
-		pGraphics.translate(x, y);
-		pGraphics.setFill(Color.BLACK);
 		pGraphics.setFont(aFont);
-		pGraphics.setTextAlign(TextAlignment.CENTER);
-		pGraphics.fillText(pEdge.getMiddleLabel(), labelBounds.getWidth()/2, 0);
-		pGraphics.setFill(oldFill);
+		STRING_VIEWER.draw(pEdge.getMiddleLabel(), pGraphics, drawingRectangle);
 		pGraphics.setFont(oldFont);
-		pGraphics.translate(-x, -y);        
 	}
 	
 	private void drawSelfEdge(Edge pEdge, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/UseCaseDependencyEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/UseCaseDependencyEdgeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.edges.UseCaseDependencyEdge;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
@@ -48,8 +50,8 @@ public final class UseCaseDependencyEdgeViewer extends LabeledStraightEdgeViewer
 		Canvas canvas = super.createIcon(pEdge);
 		final float scale = 0.75f;
 		canvas.getGraphicsContext2D().scale(scale, scale);
-		new StringViewer(StringViewer.Align.CENTER, false, false)
-		    .draw(getIconTag(pEdge), canvas.getGraphicsContext2D(), new Rectangle(1, BUTTON_SIZE, 1, 1));
+		StringViewer.get(StringViewer.VerticalAlign.CENTER, StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED))
+			.draw(getIconTag(pEdge), canvas.getGraphicsContext2D(), new Rectangle(1, BUTTON_SIZE, 1, 1));
 		return canvas;
 	}
 

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/UseCaseDependencyEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/UseCaseDependencyEdgeViewer.java
@@ -20,14 +20,14 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.edges;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.diagram.edges.UseCaseDependencyEdge;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.Canvas;
 
 /**
@@ -50,8 +50,8 @@ public final class UseCaseDependencyEdgeViewer extends LabeledStraightEdgeViewer
 		Canvas canvas = super.createIcon(pEdge);
 		final float scale = 0.75f;
 		canvas.getGraphicsContext2D().scale(scale, scale);
-		StringViewer.get(StringViewer.VerticalAlign.CENTER, StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED))
-			.draw(getIconTag(pEdge), canvas.getGraphicsContext2D(), new Rectangle(1, BUTTON_SIZE, 1, 1));
+		StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED).draw(getIconTag(pEdge), 
+				canvas.getGraphicsContext2D(), new Rectangle(1, BUTTON_SIZE, 1, 1));
 		return canvas;
 	}
 

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/AbstractPackageNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/AbstractPackageNodeViewer.java
@@ -21,6 +21,7 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
+import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.AbstractPackageNode;
@@ -43,7 +44,8 @@ public abstract class AbstractPackageNodeViewer extends AbstractNodeViewer
 	protected static final int DEFAULT_BOTTOM_HEIGHT = 60;
 	protected static final int DEFAULT_TOP_WIDTH = 60;
 	protected static final int NAME_GAP = 3;
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/AbstractPackageNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/AbstractPackageNodeViewer.java
@@ -21,7 +21,6 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
-import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.AbstractPackageNode;
@@ -30,6 +29,8 @@ import ca.mcgill.cs.jetuml.geom.Direction;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
 import javafx.scene.canvas.GraphicsContext;
 
@@ -44,8 +45,7 @@ public abstract class AbstractPackageNodeViewer extends AbstractNodeViewer
 	protected static final int DEFAULT_BOTTOM_HEIGHT = 60;
 	protected static final int DEFAULT_TOP_WIDTH = 60;
 	protected static final int NAME_GAP = 3;
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.ActorNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -38,7 +40,8 @@ import javafx.scene.shape.QuadCurveTo;
  */
 public final class ActorNodeViewer extends AbstractNodeViewer
 {
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
 	
 	private static final int PADDING = 4;
 	private static final int HEAD_SIZE = 16;

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ActorNodeViewer.java
@@ -20,14 +20,14 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.ActorNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.shape.LineTo;
@@ -40,8 +40,7 @@ import javafx.scene.shape.QuadCurveTo;
  */
 public final class ActorNodeViewer extends AbstractNodeViewer
 {
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
 	
 	private static final int PADDING = 4;
 	private static final int HEAD_SIZE = 16;

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/FieldNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/FieldNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
@@ -42,9 +44,12 @@ public final class FieldNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_WIDTH = 60;
 	private static final int DEFAULT_HEIGHT = 20;
 	private static final int XGAP = 5;
-	private static final StringViewer VALUE_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
-	private static final StringViewer EQUALS_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
+	private static final StringViewer VALUE_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer EQUALS_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
 	private static final int MID_OFFSET = EQUALS_VIEWER.getDimension(EQUALS).width() / 2;
 	private static final ObjectNodeViewer OBJECT_NODE_VIEWER = new ObjectNodeViewer();
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/FieldNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/FieldNodeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
@@ -30,6 +28,8 @@ import ca.mcgill.cs.jetuml.geom.Direction;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
@@ -44,12 +44,9 @@ public final class FieldNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_WIDTH = 60;
 	private static final int DEFAULT_HEIGHT = 20;
 	private static final int XGAP = 5;
-	private static final StringViewer VALUE_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
-	private static final StringViewer EQUALS_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer VALUE_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
+	private static final StringViewer EQUALS_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 	private static final int MID_OFFSET = EQUALS_VIEWER.getDimension(EQUALS).width() / 2;
 	private static final ObjectNodeViewer OBJECT_NODE_VIEWER = new ObjectNodeViewer();
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
@@ -21,6 +21,7 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
+import static java.util.EnumSet.of;
 
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +50,8 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 	private static final int TAIL_HEIGHT = 20; // Piece of the life line below the last call node
 	private static final int TOP_HEIGHT = 60;
 	private static final int Y_GAP_SMALL = 20; 
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, true);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.UNDERLINED, StringViewer.TextDecorations.PADDED));
 	private static final CallNodeViewer CALL_NODE_VIEWER = new CallNodeViewer();
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ImplicitParameterNodeViewer.java
@@ -21,7 +21,6 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
-import static java.util.EnumSet.of;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +35,8 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
 import javafx.scene.canvas.GraphicsContext;
 
@@ -50,8 +51,7 @@ public final class ImplicitParameterNodeViewer extends AbstractNodeViewer
 	private static final int TAIL_HEIGHT = 20; // Piece of the life line below the last call node
 	private static final int TOP_HEIGHT = 60;
 	private static final int Y_GAP_SMALL = 20; 
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.UNDERLINED, StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED, TextDecoration.UNDERLINED);
 	private static final CallNodeViewer CALL_NODE_VIEWER = new CallNodeViewer();
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/NoteNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/NoteNodeViewer.java
@@ -20,13 +20,13 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.NoteNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ToolGraphics;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
@@ -43,8 +43,7 @@ public final class NoteNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_HEIGHT = 40;
 	private static final int FOLD_LENGTH = 8;
 	private static final Color NOTE_COLOR = Color.color(0.9f, 0.9f, 0.6f); // Pale yellow
-	private static final StringViewer NOTE_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NOTE_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/NoteNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/NoteNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.NoteNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -41,7 +43,8 @@ public final class NoteNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_HEIGHT = 40;
 	private static final int FOLD_LENGTH = 8;
 	private static final Color NOTE_COLOR = Color.color(0.9f, 0.9f, 0.6f); // Pale yellow
-	private static final StringViewer NOTE_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
+	private static final StringViewer NOTE_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ObjectNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ObjectNodeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.allOf;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
@@ -30,6 +28,8 @@ import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.Grid;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
 import javafx.scene.canvas.GraphicsContext;
 
@@ -43,8 +43,8 @@ public final class ObjectNodeViewer extends AbstractNodeViewer
 	private static final int TEXT_HORIZONTAL_MARGIN = 5;
 	private static final int XGAP = 5;
 	private static final int YGAP = 5;
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, allOf(StringViewer.TextDecorations.class));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, 
+			TextDecoration.BOLD, TextDecoration.UNDERLINED, TextDecoration.PADDED);
 	private static final FieldNodeViewer FIELD_NODE_VIEWER = new FieldNodeViewer();
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/ObjectNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/ObjectNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.allOf;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.FieldNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
@@ -41,7 +43,8 @@ public final class ObjectNodeViewer extends AbstractNodeViewer
 	private static final int TEXT_HORIZONTAL_MARGIN = 5;
 	private static final int XGAP = 5;
 	private static final int YGAP = 5;
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, true, true);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, allOf(StringViewer.TextDecorations.class));
 	private static final FieldNodeViewer FIELD_NODE_VIEWER = new FieldNodeViewer();
 	
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageDescriptionNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageDescriptionNodeViewer.java
@@ -21,6 +21,7 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
+import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.AbstractPackageNode;
@@ -36,7 +37,8 @@ import javafx.scene.canvas.GraphicsContext;
  */
 public final class PackageDescriptionNodeViewer extends AbstractPackageNodeViewer
 {
-	private static final StringViewer CONTENTS_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
+	private static final StringViewer CONTENTS_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageDescriptionNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/PackageDescriptionNodeViewer.java
@@ -21,7 +21,6 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
-import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.AbstractPackageNode;
@@ -29,6 +28,8 @@ import ca.mcgill.cs.jetuml.diagram.nodes.PackageDescriptionNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 
@@ -37,8 +38,7 @@ import javafx.scene.canvas.GraphicsContext;
  */
 public final class PackageDescriptionNodeViewer extends AbstractPackageNodeViewer
 {
-	private static final StringViewer CONTENTS_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer CONTENTS_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/StateNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/StateNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.StateNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -38,7 +40,8 @@ public final class StateNodeViewer extends AbstractNodeViewer
 {
 	private static final int DEFAULT_WIDTH = 80;
 	private static final int DEFAULT_HEIGHT = 60;
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/StateNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/StateNodeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.StateNode;
 import ca.mcgill.cs.jetuml.geom.Dimension;
@@ -31,6 +29,8 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.GraphicsContext;
 
 /**
@@ -40,8 +40,7 @@ public final class StateNodeViewer extends AbstractNodeViewer
 {
 	private static final int DEFAULT_WIDTH = 80;
 	private static final int DEFAULT_HEIGHT = 60;
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/TypeNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/TypeNodeViewer.java
@@ -21,7 +21,6 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
-import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.TypeNode;
@@ -29,6 +28,8 @@ import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
 import javafx.scene.canvas.GraphicsContext;
 
@@ -43,10 +44,8 @@ public class TypeNodeViewer extends AbstractNodeViewer
 	protected static final int DEFAULT_WIDTH = 100;
 	protected static final int DEFAULT_HEIGHT = 60;
 	protected static final int TOP_INCREMENT = 20;
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.BOLD, StringViewer.TextDecorations.PADDED));
-	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
-			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.BOLD, TextDecoration.PADDED);
+	private static final StringViewer STRING_VIEWER = StringViewer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/TypeNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/TypeNodeViewer.java
@@ -21,6 +21,7 @@
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
 import static ca.mcgill.cs.jetuml.geom.GeomUtils.max;
+import static java.util.EnumSet.of;
 
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.TypeNode;
@@ -42,8 +43,10 @@ public class TypeNodeViewer extends AbstractNodeViewer
 	protected static final int DEFAULT_WIDTH = 100;
 	protected static final int DEFAULT_HEIGHT = 60;
 	protected static final int TOP_INCREMENT = 20;
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, true, false);
-	private static final StringViewer STRING_VIEWER = new StringViewer(StringViewer.Align.LEFT, false, false);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.BOLD, StringViewer.TextDecorations.PADDED));
+	private static final StringViewer STRING_VIEWER = StringViewer.get(StringViewer.VerticalAlign.TOP, 
+			StringViewer.HorizontalAlign.LEFT, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/UseCaseNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/UseCaseNodeViewer.java
@@ -20,6 +20,8 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
+import static java.util.EnumSet.of;
+
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.UseCaseNode;
 import ca.mcgill.cs.jetuml.geom.Direction;
@@ -39,7 +41,8 @@ public final class UseCaseNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_WIDTH = 110;
 	private static final int DEFAULT_HEIGHT = 40;
 	private static final int HORIZONTAL_NAME_PADDING = 30;
-	private static final StringViewer NAME_VIEWER = new StringViewer(StringViewer.Align.CENTER, false, false);
+	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
+			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/UseCaseNodeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/UseCaseNodeViewer.java
@@ -20,8 +20,6 @@
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.viewers.nodes;
 
-import static java.util.EnumSet.of;
-
 import ca.mcgill.cs.jetuml.diagram.Node;
 import ca.mcgill.cs.jetuml.diagram.nodes.UseCaseNode;
 import ca.mcgill.cs.jetuml.geom.Direction;
@@ -30,6 +28,8 @@ import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
 import ca.mcgill.cs.jetuml.views.ViewUtils;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 
@@ -41,8 +41,7 @@ public final class UseCaseNodeViewer extends AbstractNodeViewer
 	private static final int DEFAULT_WIDTH = 110;
 	private static final int DEFAULT_HEIGHT = 40;
 	private static final int HORIZONTAL_NAME_PADDING = 30;
-	private static final StringViewer NAME_VIEWER = StringViewer.get(StringViewer.VerticalAlign.CENTER, 
-			StringViewer.HorizontalAlign.CENTER, of(StringViewer.TextDecorations.PADDED));
+	private static final StringViewer NAME_VIEWER = StringViewer.get(Alignment.CENTER_CENTER, TextDecoration.PADDED);
 	
 	@Override
 	public void draw(Node pNode, GraphicsContext pGraphics)

--- a/test/ca/mcgill/cs/jetuml/views/TestStringViewer.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestStringViewer.java
@@ -1,0 +1,53 @@
+package ca.mcgill.cs.jetuml.views;
+
+import static ca.mcgill.cs.jetuml.testutils.GeometryUtils.osDependent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ca.mcgill.cs.jetuml.geom.Dimension;
+import ca.mcgill.cs.jetuml.views.StringViewer.Alignment;
+import ca.mcgill.cs.jetuml.views.StringViewer.TextDecoration;
+
+public class TestStringViewer {
+	
+	private StringViewer topCenter;
+	private StringViewer topCenterPadded;
+	private StringViewer topCenterBold;
+	private StringViewer bottomCenterPadded;
+	
+	@BeforeEach
+	public void setup()
+	{
+		topCenter = StringViewer.get(Alignment.TOP_CENTER);
+		topCenterPadded = StringViewer.get(Alignment.TOP_CENTER, TextDecoration.PADDED);
+		topCenterBold = StringViewer.get(Alignment.TOP_CENTER, TextDecoration.BOLD);
+		bottomCenterPadded = StringViewer.get(Alignment.BOTTOM_CENTER, TextDecoration.PADDED);
+	}
+	
+
+	@Test
+	public void testFlyweightProperty()
+	{
+		StringViewer stringViewer = StringViewer.get(Alignment.TOP_CENTER);
+		
+		assertNotSame(topCenterPadded, stringViewer);
+		assertNotSame(bottomCenterPadded, stringViewer);
+		assertSame(topCenter, stringViewer);
+	}
+	
+	@Test
+	public void testDimensionEmptyPaddedNoPaddedBold()
+	{
+		assertEquals(topCenter.getDimension(""), new Dimension(0, 0));
+		assertEquals(topCenterPadded.getDimension(""), new Dimension(0, 0));
+		assertEquals(topCenter.getDimension("Display String"), new Dimension(osDependent(69, 69, 69), osDependent(12, 12, 12)));
+		assertEquals(topCenterBold.getDimension("Display String"), new Dimension(osDependent(69, 69, 69), osDependent(12, 12, 12)));
+		assertEquals(topCenterPadded.getDimension("Display String"), new Dimension(osDependent(83, 83, 83), osDependent(26, 26, 26)));
+	}
+	
+	
+}


### PR DESCRIPTION
Summary of Changes:
`StringViewer` is now flyweight. Furthermore, previous enums are replaced with 3: `VerticalAlign`, `HorizontalAlign`, and `TextDecorations` (which includes bolded, underlined, and padded text, the last of which is new). To instantiate a `StringViewer`, one must pass a vertical alignment, a horizontal alignment, and an `EnumSet` containing objects of type `TextDecorations` which specify which decorations to apply. The set of these properties form the key of the `Map` representing the cache of already-created `StringViewers`

Furthermore, classes that dealt with text in some form, but not via `StringViewer`, now rely on `StringViewer` (`AbstractEdgeViewer`, `StateTransitionEdgeViewer`, and `SegmentedEdgeViewer`). These classes were what prompted the addition of the padding decoration, as well as having custom combinations of a vertical and horizontal alignment.

All classes that were broken from this change were updated as well.