### PR TITLE
Add support for Flatpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 hs_err_pid*
 /bin/
 /.settings/
+
+# Flatpak builder cache and output directories.
+.flatpak-builder/
+build/

--- a/build-aux/org.jetuml.JetUML.yaml
+++ b/build-aux/org.jetuml.JetUML.yaml
@@ -1,0 +1,100 @@
+app-id: "org.jetuml.JetUML"
+runtime: "org.freedesktop.Platform"
+runtime-version : "20.08"
+sdk: "org.freedesktop.Sdk"
+sdk-extensions : [
+  "org.freedesktop.Sdk.Extension.openjdk11"
+]
+command: "/app/bin/launch_jetuml"
+finish-args: [
+    "--socket=x11",
+    "--share=ipc",
+    "--device=dri",
+    "--filesystem=home",
+    "--env=PATH=/app/jre/bin:/usr/bin"
+]
+cleanup-commands: []
+cleanup: []
+modules:
+  -
+    name : "openjdk"
+    buildsystem : "simple"
+    build-commands :
+      - /usr/lib/sdk/openjdk11/install.sh
+  -
+    name: "JavaFX"
+    buildsystem: "simple"
+    builddir: true
+    build-commands:
+      - mkdir -p /app/javafx
+      - cp -r ./ /app/javafx
+    sources:
+      -
+        md5: "98d5d52df541dcc423e3e3b8bb0ab90d"
+        type: "archive"
+        url: "https://download2.gluonhq.com/openjfx/11.0.2/openjfx-11.0.2_linux-x64_bin-sdk.zip"
+  -
+    name: "Jupiter"
+    buildsystem: "simple"
+    builddir: true
+    build-commands:
+      - mkdir -p /app/junit
+      - cp -r ./ /app/junit
+    sources:
+      -
+        sha256: "380bde7098b4f6448f620afcdc2e3695896a57ee3620cfaa29ad274be1d78a61"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter/5.6.3/junit-jupiter-5.6.3.jar"
+      -
+        sha256: "26a22fe54dca351da9edccbcaa3c3cdcf25862cef3d2e04aa9363029a7beaa9d"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.6.3/junit-jupiter-api-5.6.3.jar"
+      -
+        sha256: "12dd6cf31f4d1d0209a2f121d1c90e97254efcd7650b4041619ece13250d2ccb"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.6.3/junit-jupiter-params-5.6.3.jar"
+      -
+        sha256: "49be6439351fdb50f0b7827e555acad26504a8084b6bc4019b2e6d73bc9da91a"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.6.3/junit-platform-commons-1.6.3.jar"
+      -
+        sha256: "fc68f0d28633caccf3980fdf1e99628fba9c49424ee56dc685cd8b4d2a9fefde"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/apiguardian/apiguardian-api/1.1.1/apiguardian-api-1.1.1.jar"
+      -
+        sha256: "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2"
+        type: "file"
+        url: "https://repo1.maven.org/maven2/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+  -
+    name: "JetUML"
+    buildsystem: "simple"
+    builddir: true
+    build-commands:
+      - mkdir -p bin/jetuml
+      - cp -r icons/** bin/jetuml/
+      - find . -name '*.java' > files.txt
+      - /usr/lib/sdk/openjdk11/bin/javac -cp test:src -p /app/javafx/lib:/app/junit --add-modules javafx.controls,javafx.swing -d bin/jetuml @files.txt
+      - cd src; cp --parent `find -name '*.css'` ../bin/jetuml
+      - cd src; cp --parent `find -name '*.properties'` ../bin/jetuml
+      - cd test; cp --parent `find -name '*.properties'` ../bin/jetuml
+      - mkdir -p /app/bin/jetuml
+      - cp -R bin/jetuml/* /app/bin/jetuml
+    sources:
+      -
+        type: "git"
+        url: "https://github.com/louib/JetUML.git"
+        branch: flatpak_manifest
+  -
+    name: "invocation"
+    buildsystem: "simple"
+    builddir: true
+    build-commands: []
+    post-install:
+      - cp launch_jetuml /app/bin/
+      - chmod +x /app/bin/launch_jetuml
+    sources:
+      -
+        type: "script"
+        dest-filename: "launch_jetuml"
+        commands:
+          - "/usr/lib/sdk/openjdk11/bin/java -cp /app/bin/jetuml -p /app/javafx/lib:/app/junit --add-modules javafx.controls,javafx.swing ca.mcgill.cs.jetuml.JetUML"

--- a/build-aux/org.jetuml.jetuml.desktop
+++ b/build-aux/org.jetuml.jetuml.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=JetUML
+Comment=A desktop application for fast UML diagramming.
+Categories=Development;Engineering;
+
+Icon=jetuml
+Exec=jetuml
+Terminal=false

--- a/build-aux/org.jetuml.jetuml.metainfo.xml
+++ b/build-aux/org.jetuml.jetuml.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.jetuml.jetuml</id>
+
+  <name>JetUML</name>
+  <summary>A desktop application for fast UML diagramming.</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+
+  <description>
+    <p>
+      A lightweight desktop application for interactively creating and editing diagrams in the Unified Modeling Language. JetUML supports the sketching of software design ideas with a minimum of fuss. Diagrams can be saved in JSON, exported to popular image formats, and copied to the system clipboard for integration with other tools. Supports class diagrams, sequence diagrams, state diagrams, object diagrams, and use case diagrams.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">org.jetuml.jetuml.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/prmr/JetUML/blob/master/docs/banner.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/src/ca/mcgill/cs/jetuml/gui/tips/TipDialog.java
+++ b/src/ca/mcgill/cs/jetuml/gui/tips/TipDialog.java
@@ -253,6 +253,9 @@ public class TipDialog
 		assert pTip != null;
 		
 		VBox tipVBox = new VBox();
+		if (pTip == null) {
+			return tipVBox;
+		}
 		tipVBox.setSpacing(TIP_ELEMENTS_SPACING);
 		tipVBox.setPadding(new Insets(PADDING));
 		

--- a/src/ca/mcgill/cs/jetuml/gui/tips/TipLoader.java
+++ b/src/ca/mcgill/cs/jetuml/gui/tips/TipLoader.java
@@ -60,6 +60,9 @@ final class TipLoader
 		try(InputStream tipsInputStream = TipLoader.class.getResourceAsStream(
 				String.format(TIP_FILE_PATH_FORMAT, pId)))
 		{
+			if (tipsInputStream == null) {
+				return null;
+			}
 			InputStreamReader tipsReader = new InputStreamReader(tipsInputStream, StandardCharsets.UTF_8);
 			JSONTokener jsonTokener = new JSONTokener(tipsReader);
 			JSONObject jsonObject = new JSONObject(jsonTokener); 


### PR DESCRIPTION
This commit adds support for distributing
the application using Flatpak, the Linux
distribution-agnostic packaging tool.

This PR is still a work in progress. After this gets merged, I will go through the [app submission process](https://github.com/flathub/flathub/wiki/App-Submission) to publish a version on Flathub.

## TODO
- [ ] Allow compiling the app without the tests.
- [ ] Figure out why the tips database is not populated in the Flatpak environment.
- [ ] Test the `.desktop` file and `metainfo` file with a local install
- [ ] Add `flatpak-builder` instructions to the dev documentation.