### PR TITLE
#446 Improvements to Edge Label Alignment and Layout

### DIFF
--- a/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/AbstractEdgeViewer.java
@@ -45,6 +45,7 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	protected static final int MAX_DISTANCE = 3;
 	protected static final int BUTTON_SIZE = 25;
 	protected static final int OFFSET = 3;
+	protected static final int MAX_LENGTH_FOR_NORMAL_FONT = 15;
 	private static final StringViewer SIZE_TESTER = StringViewer.get(Alignment.TOP_LEFT);
 	
 	private static final int DEGREES_180 = 180;
@@ -122,5 +123,21 @@ public abstract class AbstractEdgeViewer implements EdgeViewer
 	public void drawSelectionHandles(Edge pEdge, GraphicsContext pGraphics)
 	{
 		ToolGraphics.drawHandles(pGraphics, getConnectionPoints(pEdge));		
+	}
+	
+	protected String wrapLabel(String pString, int pDistanceInX, int pDistanceInY)
+	{
+		final int singleCharWidth = SIZE_TESTER.getDimension(" ").width();
+		final int singleCharHeight = SIZE_TESTER.getDimension(" ").height();
+
+		int lineLength = MAX_LENGTH_FOR_NORMAL_FONT;
+		double distanceInX = pDistanceInX / singleCharWidth;
+		double distanceInY = pDistanceInY / singleCharHeight;
+		if (distanceInX > 0)
+		{
+			double angleInDegrees = Math.toDegrees(Math.atan(distanceInY/distanceInX));
+			lineLength = Math.max(MAX_LENGTH_FOR_NORMAL_FONT, (int)((distanceInX / 4) * (1 - angleInDegrees / DEGREES_180)));
+		}
+		return SIZE_TESTER.wrapString(pString, lineLength);
 	}
 }

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
@@ -26,6 +26,7 @@ import ca.mcgill.cs.jetuml.diagram.Edge;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import ca.mcgill.cs.jetuml.views.ArrowHead;
 import ca.mcgill.cs.jetuml.views.LineStyle;
 import ca.mcgill.cs.jetuml.views.StringViewer;
@@ -60,7 +61,7 @@ public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 	public void draw(Edge pEdge, GraphicsContext pGraphics)
 	{
 		super.draw(pEdge, pGraphics);
-		String label = aLabelExtractor.apply(pEdge);
+		String label = wrapLabel(pEdge, aLabelExtractor.apply(pEdge));
 		int labelHeight = STRING_VIEWER.getDimension(label).height();
 		if( label.length() > 0 )
 		{
@@ -68,9 +69,18 @@ public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 		}
 	}
 	
+	private String wrapLabel(Edge pEdge, String pString) 
+	{
+		int distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
+				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX());
+		int distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
+				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY());
+		return super.wrapLabel(pString, distanceInX, distanceInY);
+	}
+
 	private Rectangle getStringBounds(Edge pEdge)
 	{
-		String label = aLabelExtractor.apply(pEdge);
+		String label = wrapLabel(pEdge, aLabelExtractor.apply(pEdge));
 		assert label != null && label.length() > 0;
 		Dimension dimensions = STRING_VIEWER.getDimension(label);
 		Point center = getConnectionPoints(pEdge).spanning().getCenter();

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/LabeledStraightEdgeViewer.java
@@ -61,7 +61,7 @@ public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 	public void draw(Edge pEdge, GraphicsContext pGraphics)
 	{
 		super.draw(pEdge, pGraphics);
-		String label = wrapLabel(pEdge, aLabelExtractor.apply(pEdge));
+		String label = wrapLabel(pEdge);
 		int labelHeight = STRING_VIEWER.getDimension(label).height();
 		if( label.length() > 0 )
 		{
@@ -69,18 +69,18 @@ public class LabeledStraightEdgeViewer extends StraightEdgeViewer
 		}
 	}
 	
-	private String wrapLabel(Edge pEdge, String pString) 
+	private String wrapLabel(Edge pEdge) 
 	{
 		int distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
 				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX());
 		int distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
 				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY());
-		return super.wrapLabel(pString, distanceInX, distanceInY);
+		return super.wrapLabel(aLabelExtractor.apply(pEdge), distanceInX, distanceInY);
 	}
 
 	private Rectangle getStringBounds(Edge pEdge)
 	{
-		String label = wrapLabel(pEdge, aLabelExtractor.apply(pEdge));
+		String label = wrapLabel(pEdge);
 		assert label != null && label.length() > 0;
 		Dimension dimensions = STRING_VIEWER.getDimension(label);
 		Point center = getConnectionPoints(pEdge).spanning().getCenter();

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
@@ -89,31 +89,39 @@ public class SegmentedEdgeViewer extends AbstractEdgeViewer
 	 * @param pString the string to draw 
 	 * @param pCenter true if the string should be centered along the segment
 	 */
-	private static void drawString(GraphicsContext pGraphics, Point2D pEndPoint1, Point2D pEndPoint2, 
+	private void drawString(GraphicsContext pGraphics, Point2D pEndPoint1, Point2D pEndPoint2, 
 			ArrowHead pArrowHead, String pString, boolean pCenter)
 	{
 		if (pString == null || pString.length() == 0)
 		{
 			return;
 		}
-		Rectangle bounds = getStringBounds(pEndPoint1, pEndPoint2, pArrowHead, pString, pCenter);
+		String label = wrapLabel(pString, pEndPoint1, pEndPoint2);
+		Rectangle bounds = getStringBounds(pEndPoint1, pEndPoint2, pArrowHead, label, pCenter);
 		if(pCenter) 
 		{
 			if ( pEndPoint2.getY() >= pEndPoint1.getY() )
 			{
-				TOP_CENTERED_STRING_VIEWER.draw(pString, pGraphics, bounds);
+				TOP_CENTERED_STRING_VIEWER.draw(label, pGraphics, bounds);
 			}
 			else
 			{
-				BOTTOM_CENTERED_STRING_VIEWER.draw(pString, pGraphics, bounds);
+				BOTTOM_CENTERED_STRING_VIEWER.draw(label, pGraphics, bounds);
 			}
 		}
 		else
 		{
-			LEFT_JUSTIFIED_STRING_VIEWER.draw(pString, pGraphics, bounds);
+			LEFT_JUSTIFIED_STRING_VIEWER.draw(label, pGraphics, bounds);
 		}
 	}
 	
+	private String wrapLabel(String pString, Point2D pEndPoint1, Point2D pEndPoint2) 
+	{
+		int distanceInX = (int)Math.abs(pEndPoint1.getX() - pEndPoint2.getX());
+		int distanceInY = (int)Math.abs(pEndPoint1.getY() - pEndPoint2.getY());
+		return super.wrapLabel(pString, distanceInX, distanceInY);
+	}
+
 	@Override
 	public void draw(Edge pEdge, GraphicsContext pGraphics)
 	{

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/SegmentedEdgeViewer.java
@@ -187,18 +187,18 @@ public class SegmentedEdgeViewer extends AbstractEdgeViewer
 			{
 				yoff = gap;
 			}
-			if(pArrow != null)
+			if(pArrow != null && pArrow != ArrowHead.NONE)
 			{
 				Bounds arrowBounds = pArrow.view().getPath(
 						Conversions.toPoint(pEndPoint1), 
 						Conversions.toPoint(pEndPoint2)).getBoundsInLocal();
-				if(pEndPoint1.getX() < pEndPoint2.getX())
+				if(pEndPoint1.getY() == pEndPoint2.getY())
 				{
-					xoff -= arrowBounds.getWidth();
+					yoff -= arrowBounds.getHeight() / 2;
 				}
-				else
+				else if(pEndPoint1.getX() == pEndPoint2.getX())
 				{
-					xoff += arrowBounds.getWidth();
+					xoff += arrowBounds.getWidth() / 2;
 				}
 			}
 		}

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
@@ -239,30 +239,15 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	}  
 
 	/**
-	 * Wraps the edge label, accounting for possible self-loop intersections.
+	 * Wraps the edge label.
 	 */
 	private String wrapLabel(StateTransitionEdge pEdge)
 	{
-		final int singleCharWidth = STRING_VIEWER.getDimension(" ").width();
-		
-		int lineLength = MAX_LENGTH_FOR_NORMAL_FONT;
-		if ( isSelfEdge(pEdge) )
-		{
-	    	final int nodeLength = NodeViewerRegistry.getBounds(pEdge.getStart()).getWidth() / singleCharWidth;
-	    	if ( lineLength >= nodeLength / 2 )
-	    	{
-	    		lineLength =  nodeLength / 2;
-	    	}
-	    	return STRING_VIEWER.wrapString(pEdge.getMiddleLabel(), lineLength);
-		}
-		else
-		{
-			int distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
-					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX());
-			int distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
-					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY());
-			return super.wrapLabel(pEdge.getMiddleLabel(), distanceInX, distanceInY);
-		}	
+		int distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
+				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX());
+		int distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
+				NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY());
+		return super.wrapLabel(pEdge.getMiddleLabel(), distanceInX, distanceInY);	
 	}
 
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
@@ -55,12 +55,10 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	private static final int DEGREES_5 = 5;
 	private static final int DEGREES_10 = 10;
 	private static final int DEGREES_20 = 20;
-	private static final int DEGREES_180 = 180;
 	private static final int DEGREES_270 = 270;
 	private static final double LINE_WIDTH = 0.6;
 	
 	private static final int RADIANS_TO_PIXELS = 7;
-	private static final int MAX_LENGTH_FOR_NORMAL_FONT = 15;
 	private static final StringViewer STRING_VIEWER = StringViewer.get(Alignment.CENTER_CENTER);
 	
 	// The amount of vertical difference in connection points to tolerate
@@ -246,7 +244,6 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	private String wrapLabel(StateTransitionEdge pEdge)
 	{
 		final int singleCharWidth = STRING_VIEWER.getDimension(" ").width();
-		final int singleCharHeight = STRING_VIEWER.getDimension(" ").height();
 		
 		int lineLength = MAX_LENGTH_FOR_NORMAL_FONT;
 		if ( isSelfEdge(pEdge) )
@@ -256,20 +253,16 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	    	{
 	    		lineLength =  nodeLength / 2;
 	    	}
+	    	return STRING_VIEWER.wrapString(pEdge.getMiddleLabel(), lineLength);
 		}
 		else
 		{
-			double distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
-					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX()) / singleCharWidth;
-			double distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
-					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY()) / singleCharHeight;
-			if (distanceInX > 0)
-			{
-				double angleInDegrees = Math.toDegrees(Math.atan(distanceInY/distanceInX));
-				lineLength = Math.max(MAX_LENGTH_FOR_NORMAL_FONT, (int)((distanceInX / 4) * (1 - angleInDegrees / DEGREES_180)));
-			}
-		}
-		return STRING_VIEWER.wrapString(pEdge.getMiddleLabel(), lineLength);	
+			int distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
+					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX());
+			int distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
+					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY());
+			return super.wrapLabel(pEdge.getMiddleLabel(), distanceInX, distanceInY);
+		}	
 	}
 
 	@Override

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StateTransitionEdgeViewer.java
@@ -55,6 +55,7 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	private static final int DEGREES_5 = 5;
 	private static final int DEGREES_10 = 10;
 	private static final int DEGREES_20 = 20;
+	private static final int DEGREES_180 = 180;
 	private static final int DEGREES_270 = 270;
 	private static final double LINE_WIDTH = 0.6;
 	
@@ -244,17 +245,30 @@ public final class StateTransitionEdgeViewer extends AbstractEdgeViewer
 	 */
 	private String wrapLabel(StateTransitionEdge pEdge)
 	{
+		final int singleCharWidth = STRING_VIEWER.getDimension(" ").width();
+		final int singleCharHeight = STRING_VIEWER.getDimension(" ").height();
+		
 		int lineLength = MAX_LENGTH_FOR_NORMAL_FONT;
 		if ( isSelfEdge(pEdge) )
 		{
-			final int singleCharWidth = STRING_VIEWER.getDimension(" ").width();
 	    	final int nodeLength = NodeViewerRegistry.getBounds(pEdge.getStart()).getWidth() / singleCharWidth;
 	    	if ( lineLength >= nodeLength / 2 )
 	    	{
 	    		lineLength =  nodeLength / 2;
 	    	}
 		}
-		
+		else
+		{
+			double distanceInX = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getX() -
+					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getX()) / singleCharWidth;
+			double distanceInY = Math.abs(NodeViewerRegistry.getBounds(pEdge.getStart()).getCenter().getY() -
+					NodeViewerRegistry.getBounds(pEdge.getEnd()).getCenter().getY()) / singleCharHeight;
+			if (distanceInX > 0)
+			{
+				double angleInDegrees = Math.toDegrees(Math.atan(distanceInY/distanceInX));
+				lineLength = Math.max(MAX_LENGTH_FOR_NORMAL_FONT, (int)((distanceInX / 4) * (1 - angleInDegrees / DEGREES_180)));
+			}
+		}
 		return STRING_VIEWER.wrapString(pEdge.getMiddleLabel(), lineLength);	
 	}
 

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestAssociationEdgeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestAssociationEdgeViewer.java
@@ -8,11 +8,14 @@ import java.lang.reflect.Method;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.views.ArrowHead;
 import javafx.geometry.Point2D;
 
 public class TestAssociationEdgeViewer 
 {
 	private AssociationEdgeViewer aAssociationEdgeViewer = new AssociationEdgeViewer();
+	private ArrowHead aArrowHead = ArrowHead.DIAMOND;
 	
 	@ParameterizedTest
 	@CsvSource(value = {
@@ -30,6 +33,35 @@ public class TestAssociationEdgeViewer
 		assertEquals(pExpectedNumberOfLines, numberOfLines);
 	}
 	
+	@ParameterizedTest
+	@CsvSource(value = {
+			"0, 0, 0, 100, 15, 15, false, false, 9, 82",
+			"0, 0, 0, 100, 15, 15, true, false, 3, 32",
+			"0, 0, 0, 100, 1, 1, true, false, 3, 46",
+			"100, 0, 0, 100, 1, 1, true, false, 53, 46",
+			"0, 100, 0, 0, 1, 1, false, false, 9, 3",
+			"100, 500, 200, 500, 15, 15, false, false, 182, 475",
+			"100, 500, 200, 500, 15, 15, true, false, 143, 482",
+			"100, 500, 200, 500, 1, 1, true, false, 150, 496",
+			"100, 500, 200, 500, 150, 150, true, false, 203, 347",
+			"100, 500, 200, 500, 10, 10, true, true, 145, 487",
+			"100, 100, 100, 500, 10, 10, true, true, 103, 303"
+	})
+	public void testGetAttachmentPoint(int pPoint1X, int pPoint1Y, int pPoint2X, int pPoint2Y, 
+			int pTextDimensionWidth, int pTextDimensionHeight, boolean pCenter, 
+			boolean pIsStepUp, int pExpectedX, int pExpectedY)
+	{
+		Point2D point1 = new Point2D(pPoint1X, pPoint1Y);
+		Point2D point2 = new Point2D(pPoint2X, pPoint2Y);
+		Rectangle textBounds = new Rectangle(0, 0, pTextDimensionWidth, pTextDimensionHeight);
+		Point2D result = getAttachmentPoint(point1, point2, aArrowHead, textBounds, pCenter, pIsStepUp);
+		assertEquals(pExpectedX, (int)result.getX());
+		assertEquals(pExpectedY, (int)result.getY());
+	}
+	
+	/**
+	 * Calls the private method SegmentedEdgeViewer.wrapLabel(...) with the given parameters. 
+	 */
 	private String wrapLabel(String pString, Point2D pPoint1, Point2D pPoint2) 
 	{
 		try 
@@ -44,6 +76,29 @@ public class TestAssociationEdgeViewer
 			assert false;
 			fail();
 			return "";
+		}
+	}
+	
+	/**
+	 * Calls the private method SegmentedEdgeViewer.getAttachmentPoint(...) with the given parameters. 
+	 */
+	private Point2D getAttachmentPoint(Point2D pEndPoint1, Point2D pEndPoint2, 
+			ArrowHead pArrow, Rectangle pDimension, boolean pCenter, boolean pIsStepUp) 
+	{
+		try 
+		{
+			Method method = SegmentedEdgeViewer.class.getDeclaredMethod("getAttachmentPoint", 
+					Point2D.class, Point2D.class, ArrowHead.class, Rectangle.class, boolean.class, boolean.class);
+			method.setAccessible(true);
+			Point2D point = (Point2D)method.invoke(aAssociationEdgeViewer, 
+					pEndPoint1, pEndPoint2, pArrow, pDimension, pCenter, pIsStepUp);
+			return point;
+		} 
+		catch (ReflectiveOperationException e)
+		{
+			assert false;
+			fail();
+			return null;
 		}
 	}
 }

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestAssociationEdgeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestAssociationEdgeViewer.java
@@ -1,0 +1,49 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import javafx.geometry.Point2D;
+
+public class TestAssociationEdgeViewer 
+{
+	private AssociationEdgeViewer aAssociationEdgeViewer = new AssociationEdgeViewer();
+	
+	@ParameterizedTest
+	@CsvSource(value = {
+			"apple banana orange kiwi peach grape raspberry, 1000, 100, 1", 
+			"apple banana orange kiwi peach grape raspberry, 250, 100, 2",
+			"apple banana orange kiwi peach grape raspberry, 200, 200, 3",
+			"apple banana orange kiwi peach grape raspberry, 100, 0, 4"
+	})
+	public void testWrapLabel(String pString, int pDistanceInX, int pDistanceInY, int pExpectedNumberOfLines)
+	{
+		Point2D point1 = new Point2D(0.0, 0.0);
+		Point2D point2 = new Point2D(pDistanceInX, pDistanceInY);
+		String label = wrapLabel(pString, point1, point2);
+		int numberOfLines = (int)label.chars().filter(c -> c == '\n').count() + 1;
+		assertEquals(pExpectedNumberOfLines, numberOfLines);
+	}
+	
+	private String wrapLabel(String pString, Point2D pPoint1, Point2D pPoint2) 
+	{
+		try 
+		{
+			Method method = SegmentedEdgeViewer.class.getDeclaredMethod("wrapLabel", String.class, Point2D.class, Point2D.class);
+			method.setAccessible(true);
+			String label = (String)method.invoke(aAssociationEdgeViewer, pString, pPoint1, pPoint2);
+			return label;
+		} 
+		catch (ReflectiveOperationException e)
+		{
+			assert false;
+			fail();
+			return "";
+		}
+	}
+}

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestStateTransitionEdgeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestStateTransitionEdgeViewer.java
@@ -1,0 +1,67 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.edges.StateTransitionEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.StateNode;
+
+public class TestStateTransitionEdgeViewer 
+{
+	private StateNode aStateNode1;
+	private StateNode aStateNode2;
+	private StateTransitionEdge aTransitionEdge;
+	private Diagram aDiagram;
+	private StateTransitionEdgeViewer aStateTransitionEdgeViewer = new StateTransitionEdgeViewer();
+	
+	@BeforeEach
+	void setup()
+	{
+		aDiagram = new Diagram(DiagramType.STATE);
+		aStateNode1 = new StateNode();
+		aTransitionEdge = new StateTransitionEdge();
+	}
+	
+	@ParameterizedTest
+	@CsvSource(value = {
+			"apple banana orange kiwi peach grape raspberry, 1000, 100, 1", 
+			"apple banana orange kiwi peach grape raspberry, 250, 100, 2",
+			"apple banana orange kiwi peach grape raspberry, 200, 200, 3",
+			"apple banana orange kiwi peach grape raspberry, 100, 0, 4"
+	})
+	public void testWrapLabelForEdgeBetweenTwoStates(String pString, int pDistanceInX, int pDistanceInY, int pExpectedNumberOfLines)
+	{
+		aStateNode2 = new StateNode();
+		aStateNode2.translate(pDistanceInX, pDistanceInY);
+		aTransitionEdge.setMiddleLabel(pString);
+		aTransitionEdge.connect(aStateNode1, aStateNode2, aDiagram);
+		String label = wrapLabel(aTransitionEdge);
+		int numberOfLines = (int)label.chars().filter(c -> c == '\n').count() + 1;
+		assertEquals(pExpectedNumberOfLines, numberOfLines);
+	}
+
+	private String wrapLabel(StateTransitionEdge pTransitionEdge) 
+	{
+		try 
+		{
+			Method method = StateTransitionEdgeViewer.class.getDeclaredMethod("wrapLabel", StateTransitionEdge.class);
+			method.setAccessible(true);
+			String label = (String)method.invoke(aStateTransitionEdgeViewer, pTransitionEdge);
+			return label;
+		} 
+		catch (ReflectiveOperationException e)
+		{
+			assert false;
+			fail();
+			return "";
+		}
+	}
+}


### PR DESCRIPTION
The line lengths of LabeledStraightEdges, SegmentedEdges, and StateTransitionEdges is now determined dynamically based on the horizontal and vertical distances between the two points that the segment relates. During this code addition, it was noticed that some code for StateTransitionEdge label wrapping was unreachable so it was removed. 

The labels of horizontal segments now hover above the arrowhead to match the behaviour of vertical segment labels. 

The labels of SegmentedEdges no longer overlaps with the segments themselves. Logic was added to the relevant method to be able to differentiate between a "step up" segment and a "step down" segment. Before the modifications of this pull request, the behaviour was different for two same nodes connected by an edge when the nodes were inverted left to right in the diagram. 

Unit tests were added to cover all lines of code added. 

Demo for class diagram:

https://user-images.githubusercontent.com/43301868/142680455-647895e7-ab60-4190-8c3f-7de73e2c7668.mov

Demo for state diagram: 

https://user-images.githubusercontent.com/43301868/142680445-14a55205-7b3c-4431-85ea-8c4e5b2de85b.mov


