### PR TITLE
#437 Fix Downstream ImplicitParameterNode removal when a ConstructorEdge removed

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -19,5 +19,10 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin/jetuml"/>
 </classpath>

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -39,6 +39,7 @@ import ca.mcgill.cs.jetuml.diagram.edges.CallEdge;
 import ca.mcgill.cs.jetuml.diagram.edges.ConstructorEdge;
 import ca.mcgill.cs.jetuml.diagram.nodes.CallNode;
 import ca.mcgill.cs.jetuml.diagram.nodes.ImplicitParameterNode;
+import ca.mcgill.cs.jetuml.diagram.nodes.ObjectNode;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.viewers.edges.EdgeViewerRegistry;
 import ca.mcgill.cs.jetuml.viewers.nodes.ImplicitParameterNodeViewer;
@@ -123,8 +124,13 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 				result.add(edgeStart.get());
 			}
 			result.addAll(flow.getEdgeDownStreams((Edge)pElement));
+			
 		}	
 		result.addAll(flow.getCorrespondingReturnEdges(result));
+		if (pElement instanceof ConstructorEdge) 
+		{
+			result.removeIf(element -> element instanceof ImplicitParameterNode);
+		}
 		return result;
 	}
 	

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -127,6 +127,7 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 			
 		}	
 		result.addAll(flow.getCorrespondingReturnEdges(result));
+		//Implicit parameter nodes downstream of constructor calls should not be removed
 		if (pElement instanceof ConstructorEdge) 
 		{
 			result.removeIf(element -> element instanceof ImplicitParameterNode);

--- a/src/ca/mcgill/cs/jetuml/viewers/nodes/NodeViewerRegistry.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/nodes/NodeViewerRegistry.java
@@ -87,7 +87,7 @@ public final class NodeViewerRegistry
 	
    	/**
      * Tests whether pNode contains a point.
-     * @param pNode the edge to test
+     * @param pNode the node to test
      * @param pPoint the point to test
      * @return true if this element contains aPoint
      */
@@ -109,7 +109,7 @@ public final class NodeViewerRegistry
    	
 	/**
      * Draws pNode.
-     * @param pNode The edge to draw.
+     * @param pNode The node to draw.
      * @param pGraphics the graphics context
      * @pre pNode != null
 	 */
@@ -120,7 +120,7 @@ public final class NodeViewerRegistry
    	
    	/**
      * Draw selection handles around pNode.
-     * @param pNode The target edge
+     * @param pNode The target node
      * @param pGraphics the graphics context
      * @pre pNode != null && pGraphics != null
 	 */

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -100,13 +100,14 @@ public class TestControlFlow
 	}
 	
 	/*
-	 * aCall1 and aCall2 are on aParameter1
-	 * aCall3 and aCall4 are on aParameter2
-	 * aCall5 and aCall6 are on aParameter3
-	 * aCall1 calls aCall3, then aCalls2 
-	 * aCall2 calls aCall4 then returns
-	 * aCall4 calls aCall5
-	 * aCall1 calls aCall6
+	 * aCall1 is on aParameter1
+	 * aCall2 and aCall3 are on aParameter2
+	 * aCall4 and aCall5 are on aParameter3
+	 * aConstructorEdge connects aCall1 to aCall2
+	 * aCall2 returns to aCall1 
+	 * aCall2 calls aCall3
+	 * aCall3 calls aCall4
+	 * aCall2 calls aCall5
 	 */
 	private void createSampleDiagram1()
 	{

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -34,7 +34,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ca.mcgill.cs.jetuml.JavaFXLoader;
+import ca.mcgill.cs.jetuml.diagram.ControlFlow;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramAccessor;
 import ca.mcgill.cs.jetuml.diagram.DiagramElement;
 import ca.mcgill.cs.jetuml.diagram.DiagramType;
 import ca.mcgill.cs.jetuml.diagram.Node;
@@ -55,6 +57,8 @@ public class TestSequenceDiagramBuilder
 	private CallNode aDefaultCallNode1;
 	private CallNode aDefaultCallNode2;
 	private CallEdge aCallEdge1;
+	private ConstructorEdge aConstructorEdge;
+	
 	
 	@BeforeAll
 	public static void setupClass()
@@ -72,6 +76,7 @@ public class TestSequenceDiagramBuilder
 		aDefaultCallNode1 = new CallNode();
 		aDefaultCallNode2 = new CallNode();
 		aCallEdge1 = new CallEdge();
+		aConstructorEdge = new ConstructorEdge();
 	}
 	
 	private int numberOfRootNodes()
@@ -244,7 +249,7 @@ public class TestSequenceDiagramBuilder
 	}
 	
 	@Test
-	public void testGetCoRemovals()
+	public void testGetCoRemovals_CallEdge()
 	{
 		aCallEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
 		aDiagram.addEdge(aCallEdge1);
@@ -256,5 +261,23 @@ public class TestSequenceDiagramBuilder
 		assertTrue(elements.contains(aDefaultCallNode1));
 		assertTrue(elements.contains(aDefaultCallNode2));
 		assertTrue(elements.contains(aCallEdge1));
+	}
+	@Test
+	public void testGetCoRemovals_ConstructorEdge()
+	{
+		aConstructorEdge.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aDiagram.addEdge(aConstructorEdge);
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		Collection<DiagramElement> elements = new HashSet<>();
+		elements.addAll(aBuilder.getCoRemovals(aConstructorEdge));
+		assertEquals(3, elements.size());
+		assertFalse(elements.contains(aImplicitParameterNode1));
+		assertFalse(elements.contains(aImplicitParameterNode2));
+		assertTrue(elements.contains(aDefaultCallNode1));
+		assertTrue(elements.contains(aDefaultCallNode2));
+		assertTrue(elements.contains(aConstructorEdge));
 	}
 }


### PR DESCRIPTION
SequenceDiagramBuilder.getCoRemovals() now includes line which checks whether the explicit parameter is an object of type ConstructorEdge, and if so, removes downstream objects of type ImplicitParameterNode. This ensures that when a constructor edge is removed, its downstream implicit parameter nodes are not also removed, in order to be consistent with the effects of deleting call edges. A unit test for this specific change was also produced. 

Below are images showing the fix:
![image](https://user-images.githubusercontent.com/90351737/149239257-74f99f70-0003-40b5-9512-bcd4a9d33b83.png)

![image](https://user-images.githubusercontent.com/90351737/149239272-ab76294f-2247-4fa8-9490-bff05e1f781f.png)

