### PR TITLE
Issue#437 Fix get co-removals for sequence diagrams

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -9,12 +9,12 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX14">
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/ca/mcgill/cs/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -125,6 +125,11 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 			result.addAll(flow.getEdgeDownStreams((Edge)pElement));
 		}	
 		result.addAll(flow.getCorrespondingReturnEdges(result));
+		//Implicit parameter nodes downstream of constructor calls should not be removed
+		if (pElement instanceof ConstructorEdge) 
+		{
+			result.removeIf(element -> element instanceof ImplicitParameterNode);
+		}
 		return result;
 	}
 	

--- a/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/TestControlFlow.java
@@ -100,13 +100,14 @@ public class TestControlFlow
 	}
 	
 	/*
-	 * aCall1 and aCall2 are on aParameter1
-	 * aCall3 and aCall4 are on aParameter2
-	 * aCall5 and aCall6 are on aParameter3
-	 * aCall1 calls aCall3, then aCalls2 
-	 * aCall2 calls aCall4 then returns
-	 * aCall4 calls aCall5
-	 * aCall1 calls aCall6
+	 * aCall1 is on aParameter1
+	 * aCall2 and aCall3 are on aParameter2
+	 * aCall4 and aCall5 are on aParameter3
+	 * aConstructorEdge connects aCall1 to aCall2
+	 * aReturnEdge connects aCall2 to aCall1
+	 * aCall2 calls aCall3
+	 * aCall3 calls aCall4
+	 * aCall2 calls aCall5
 	 */
 	private void createSampleDiagram1()
 	{

--- a/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
+++ b/test/ca/mcgill/cs/jetuml/diagram/builder/TestSequenceDiagramBuilder.java
@@ -55,6 +55,7 @@ public class TestSequenceDiagramBuilder
 	private CallNode aDefaultCallNode1;
 	private CallNode aDefaultCallNode2;
 	private CallEdge aCallEdge1;
+	private ConstructorEdge aConstructorEdge;
 	
 	@BeforeAll
 	public static void setupClass()
@@ -244,7 +245,7 @@ public class TestSequenceDiagramBuilder
 	}
 	
 	@Test
-	public void testGetCoRemovals()
+	public void testGetCoRemovals_CallEdge()
 	{
 		aCallEdge1.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
 		aDiagram.addEdge(aCallEdge1);
@@ -257,4 +258,23 @@ public class TestSequenceDiagramBuilder
 		assertTrue(elements.contains(aDefaultCallNode2));
 		assertTrue(elements.contains(aCallEdge1));
 	}
+	
+	public void testGetCoRemovals_ConstructorEdge()
+	{
+		aConstructorEdge.connect(aDefaultCallNode1, aDefaultCallNode2, aDiagram);
+		aDiagram.addEdge(aConstructorEdge);
+		aImplicitParameterNode1.addChild(aDefaultCallNode1);
+		aImplicitParameterNode2.addChild(aDefaultCallNode2);
+		aDiagram.addRootNode(aImplicitParameterNode1);
+		aDiagram.addRootNode(aImplicitParameterNode2);
+		Collection<DiagramElement> elements = new HashSet<>();
+		elements.addAll(aBuilder.getCoRemovals(aConstructorEdge));
+		assertEquals(3, elements.size());
+		assertFalse(elements.contains(aImplicitParameterNode1));
+		assertFalse(elements.contains(aImplicitParameterNode2));
+		assertTrue(elements.contains(aDefaultCallNode1));
+		assertTrue(elements.contains(aDefaultCallNode2));
+		assertTrue(elements.contains(aConstructorEdge));
+	}
+	
 }


### PR DESCRIPTION
Changes were made to fix issue #437, ensuring that when the user deletes a `ConstructorEdge`, downstream `ImplicitParameterNode` objects are not deleted, as well. 

To fix this, a conditional statement was added to `SequenceDiagramBuilder.getCoRemovals()` which checks if the input diagram element is a `ConstructorEdge`. If so, downstream `ImplicitParameterNode` objects are removed from the list to be returned. A new test was written to consider the behavior of `getCoRemovals()` with a `ConstructorEdge`. An unrelated annotation error was also fixed in `TestControlFlow`. 

**Here is an example scenario:**
![image](https://user-images.githubusercontent.com/90351737/149639978-922a8ee4-0aad-4ad7-a476-5eaa15b37437.png)

Before applying this fix:
![image](https://user-images.githubusercontent.com/90351737/149640047-a311160f-4659-4dc9-9975-c8cf67914b13.png)

After fixing applying this fix:
![image](https://user-images.githubusercontent.com/90351737/149639988-b02e5c0d-779f-4be8-93a7-17515ab5a5ba.png)
