### PR TITLE
Bug fix 445

### DIFF
--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -47,6 +47,7 @@ import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Line;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import ca.mcgill.cs.jetuml.views.DiagramViewer;
 import ca.mcgill.cs.jetuml.views.Grid;
 import javafx.scene.input.MouseEvent;
@@ -453,14 +454,36 @@ public class DiagramCanvasController
 	private void alignMoveToGrid()
 	{
 		Iterator<Node> selectedNodes = aSelectionModel.getSelectedNodes().iterator();
+		Rectangle entireBounds = aSelectionModel.getEntireSelectionBounds();
+		
 		if( selectedNodes.hasNext() )
 		{
 			// Pick one node in the selection model, arbitrarily
 			Node firstSelected = selectedNodes.next();
-			Point position = firstSelected.position();
-			Point snappedPosition = Grid.snapped(position);
-			final int dx = snappedPosition.getX() - position.getX();
-			final int dy = snappedPosition.getY() - position.getY();
+			Rectangle bounds = NodeViewerRegistry.getBounds(firstSelected);
+			Rectangle snappedPosition = Grid.snapped(bounds);
+			
+			int dx = snappedPosition.getX() - bounds.getX();
+			int dy = snappedPosition.getY() - bounds.getY();
+			
+			//ensure the bounds of the entire selection are not outside the walls of the canvas
+			if (entireBounds.getMaxX() + dx > aCanvas.getWidth()) 
+			{
+				dx -= GRID_SIZE;
+			}
+			else if (entireBounds.getX() + dx <= 0) 
+			{
+				dx += GRID_SIZE;
+			}
+			if (entireBounds.getMaxY() + dy > aCanvas.getHeight()) 
+			{
+				dy -= GRID_SIZE;
+			}
+			else if (entireBounds.getY() <= 0) 
+			{
+				dy += GRID_SIZE;
+			}
+			
 			for(Node selected : aSelectionModel.getSelectedNodes())
 			{
 				selected.translate(dx, dy);


### PR DESCRIPTION
This addresses the issues brought in in #445 . However, we could now open a separate bug ticket for the following: on a "MouseDragged" event, we handle the movement of the selection in DiagramCanvasController::moveSelection. In the case where the entire selection bounds is close the wall of the canvas, we obtain an upper bound on the tracking speed due to the logic in DiagramCanvasController::moveSelection. This could be fixed by only checking whether we exceed the "relevant" canvas bounds: the canvas bounds that the "entire selection bounds" are approaching.