### PR TITLE
#375 Add EdgePath, EdgeStorage, and EdgePriority

### DIFF
--- a/src/ca/mcgill/cs/jetuml/geom/EdgePath.java
+++ b/src/ca/mcgill/cs/jetuml/geom/EdgePath.java
@@ -1,0 +1,125 @@
+package ca.mcgill.cs.jetuml.geom;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents the path of an edge on a diagram as a list of points. 
+ * Non-segmented paths consist of 2 points (the start and end points).
+ */
+public class EdgePath implements Iterable<Point>
+{
+	private List<Point> aPoints;
+	
+	/**
+	 * Initializes an EdgePath composed of pPoints.
+	 * @param pPoints the points of an edge (the start point, possible segment connections, and the end point)
+	 * @pre pPoints.length >= 2
+	 */
+	public EdgePath(Point...pPoints)
+	{
+		assert pPoints.length >= 2;
+		aPoints = Arrays.asList(pPoints);
+	}
+	
+	/**
+	 * Constructor for EdgePath using lines as arguments.
+	 * @param pLines the line segment(s) which compose the path.
+	 * @pre pLines.length() > 0
+	 */
+	public EdgePath(Line...pLines)
+	{
+		assert pLines.length > 0;
+		aPoints.add(pLines[0].getPoint1());
+		for (Line line : pLines)
+		{
+			aPoints.add(line.getPoint2());
+		}
+	}
+	
+
+	/**
+	 * Gets the starting point for the path.
+	 * @return the Point where the edge starts.
+	 */
+	public Point getStartPoint()
+	{
+		return aPoints.get(0);
+	}
+	
+	/**
+	 * Gets the end point of the edge.
+	 * @return the Point where the edge ends.
+	 */
+	public Point getEndPoint()
+	{
+		return aPoints.get(aPoints.size()-1);
+	}
+
+	/**
+	 * Returns the point in the edge path at position pIndex, where index 0 refers to the start point.
+	 * @param pIndex the index of aPoints
+	 * @return the Point in aPoints at pIndex < aPoints.size()
+	 * @pre pIndex > 0 && pIndex
+	 */
+	public Point getPointByIndex(int pIndex)
+	{
+		assert pIndex >= 0 && pIndex < aPoints.size();
+		return aPoints.get(pIndex);
+	}
+
+	@Override
+	public int hashCode() 
+	{
+		return Objects.hash(aPoints);
+	}
+
+	@Override
+	public boolean equals(Object pObj) 
+	{
+		if (this == pObj)
+		{
+			return true;
+		}
+		if (pObj == null)
+		{
+			return false;
+		}
+		if (getClass() != pObj.getClass())
+		{
+			return false;
+		}
+		EdgePath other = (EdgePath) pObj;
+		if (other.aPoints.size() != this.aPoints.size())
+		{
+			return false;
+		}
+		for (int i = 0; i < aPoints.size(); i++)
+		{
+			if (!other.aPoints.get(i).equals(aPoints.get(i)))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * Returns the number of points in the path.
+	 * @return an integer representing the size of the EdgePath
+	 */
+	public int size()
+	{
+		return aPoints.size();
+	}
+
+	@Override
+	public Iterator<Point> iterator() 
+	{
+		return aPoints.iterator();
+	}
+	
+	
+}

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvas.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvas.java
@@ -19,7 +19,7 @@
  * along with this program.  If not, see http://www.gnu.org/licenses.
  *******************************************************************************/
 package ca.mcgill.cs.jetuml.gui;
-
+import static ca.mcgill.cs.jetuml.diagram.DiagramType.viewerFor;
 import ca.mcgill.cs.jetuml.application.UserPreferences;
 import ca.mcgill.cs.jetuml.application.UserPreferences.BooleanPreference;
 import ca.mcgill.cs.jetuml.application.UserPreferences.BooleanPreferenceChangeHandler;
@@ -144,7 +144,7 @@ public class DiagramCanvas extends Canvas implements SelectionObserver, BooleanP
 	 */
 	private static Dimension getDiagramCanvasWidth(Diagram pDiagram)
 	{
-		Rectangle bounds = DiagramViewer.getBounds(pDiagram);
+		Rectangle bounds = viewerFor(pDiagram).getBounds(pDiagram);
 		return new Dimension(
 				Math.max(getPreferredDiagramWidth(), bounds.getMaxX() + DIMENSION_BUFFER),
 				Math.max(getPreferredDiagramHeight(), bounds.getMaxY() + DIMENSION_BUFFER));

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -276,7 +276,7 @@ public class DiagramCanvasController
 	{
 		Point mousePoint = getMousePoint(pEvent);
 		Optional<? extends DiagramElement> element = 
-				DiagramViewer.edgeAt(aDiagramBuilder.getDiagram(), mousePoint);
+				viewerFor(aDiagramBuilder.getDiagram()).edgeAt(aDiagramBuilder.getDiagram(), mousePoint);
 		if(!element.isPresent())
 		{
 			element = viewerFor(aDiagramBuilder.getDiagram())

--- a/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
@@ -21,6 +21,28 @@ import javafx.scene.canvas.GraphicsContext;
  * Unlike other DiagramViwers, ClassDiagramViewer stateful. 
  *
  */
+
+import java.util.List;
+import java.util.Optional;
+
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramElement;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.edges.EdgeStorage;
+import ca.mcgill.cs.jetuml.viewers.edges.EdgeViewerRegistry;
+import ca.mcgill.cs.jetuml.viewers.edges.StoredEdgeViewer;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+import javafx.scene.canvas.GraphicsContext;
+
+/**
+ * Viewer for ClassDiagrams which stores the EdgePaths for edges in the diagram which were planned by Layouter.
+ * Unlike other DiagramViwers, ClassDiagramViewer stateful. 
+ *
+ */
 public class ClassDiagramViewer extends DiagramViewer
 {
 	
@@ -42,11 +64,11 @@ public class ClassDiagramViewer extends DiagramViewer
 		NodeViewerRegistry.activateNodeStorages();
 		pDiagram.rootNodes().forEach(node -> super.drawNode(node, pGraphics));
 		
-		//plan EdgePaths using Layouter
+		//plan edge paths using Layouter
 		aEdgeStorage.clearStorage();
 		aLayouter.layout(pDiagram);
 		
-		//draw edges using EdgeStorage
+		//draw edges using plan from EdgeStorage
 		for (Edge edge : pDiagram.edges())
 		{
 			if (aEdgeStorage.contains(edge))

--- a/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
@@ -22,27 +22,6 @@ import javafx.scene.canvas.GraphicsContext;
  *
  */
 
-import java.util.List;
-import java.util.Optional;
-
-import ca.mcgill.cs.jetuml.diagram.Diagram;
-import ca.mcgill.cs.jetuml.diagram.DiagramElement;
-import ca.mcgill.cs.jetuml.diagram.Edge;
-import ca.mcgill.cs.jetuml.diagram.Node;
-import ca.mcgill.cs.jetuml.geom.EdgePath;
-import ca.mcgill.cs.jetuml.geom.Point;
-import ca.mcgill.cs.jetuml.geom.Rectangle;
-import ca.mcgill.cs.jetuml.viewers.edges.EdgeStorage;
-import ca.mcgill.cs.jetuml.viewers.edges.EdgeViewerRegistry;
-import ca.mcgill.cs.jetuml.viewers.edges.StoredEdgeViewer;
-import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
-import javafx.scene.canvas.GraphicsContext;
-
-/**
- * Viewer for ClassDiagrams which stores the EdgePaths for edges in the diagram which were planned by Layouter.
- * Unlike other DiagramViwers, ClassDiagramViewer stateful. 
- *
- */
 public class ClassDiagramViewer extends DiagramViewer
 {
 	

--- a/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/ClassDiagramViewer.java
@@ -1,0 +1,230 @@
+package ca.mcgill.cs.jetuml.viewers;
+import java.util.List;
+import java.util.Optional;
+
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramElement;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.edges.EdgeStorage;
+import ca.mcgill.cs.jetuml.viewers.edges.EdgeViewerRegistry;
+import ca.mcgill.cs.jetuml.viewers.edges.StoredEdgeViewer;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+import javafx.scene.canvas.GraphicsContext;
+
+/**
+ * Viewer for ClassDiagrams.
+ * Uses Layouter to plan and store the EdgePaths of edges. Uses StoredEdgeViewer to draw the stored edges. 
+ * Unlike other DiagramViwers, ClassDiagramViewer stateful. 
+ *
+ */
+public class ClassDiagramViewer extends DiagramViewer
+{
+	
+	private static final StoredEdgeViewer STORED_EDGE_VIEWER = new StoredEdgeViewer();
+	private final EdgeStorage aEdgeStorage = new EdgeStorage();
+	private final Layouter aLayouter = new Layouter();
+	
+	/**
+	 * Draws pDiagram onto pGraphics.
+	 * 
+	 * @param pGraphics the graphics context where the
+	 *     diagram should be drawn.
+	 * @param pDiagram the diagram to draw.
+	 * @pre pDiagram != null && pGraphics != null.
+	 */
+	public void draw(Diagram pDiagram, GraphicsContext pGraphics)
+	{
+		//draw and store nodes 
+		NodeViewerRegistry.activateNodeStorages();
+		pDiagram.rootNodes().forEach(node -> super.drawNode(node, pGraphics));
+		
+		//plan EdgePaths using Layouter
+		aEdgeStorage.clearStorage();
+		aLayouter.layout(pDiagram);
+		
+		//draw edges using EdgeStorage
+		for (Edge edge : pDiagram.edges())
+		{
+			if (aEdgeStorage.contains(edge))
+			{
+				STORED_EDGE_VIEWER.draw(edge, pGraphics);
+			}
+			else
+			{	//For edges which are not stored (note edges)
+				EdgeViewerRegistry.draw(edge, pGraphics);
+			}
+		}
+		NodeViewerRegistry.deactivateAndClearNodeStorages();
+	}
+	
+	/**
+	 * Returns the edge underneath the given point, if it exists.
+	 * 
+	 * @param pDiagram The diagram to query
+	 * @param pPoint a point
+	 * @return An edge containing pPoint or Optional.empty() if no edge is under pPoint
+	 * @pre pDiagram != null && pPoint != null
+	 */
+	public final Optional<Edge> edgeAt(Diagram pDiagram, Point pPoint)
+	{
+		assert pDiagram != null && pPoint != null;
+		Optional<Edge> storedEdge =  pDiagram.edges().stream()
+				.filter(edge -> STORED_EDGE_VIEWER.contains(edge, pPoint))
+				.findFirst();
+		if (storedEdge.isEmpty())
+		{
+			//check if a Note edge is is at pPoint
+			return pDiagram.edges().stream()
+					.filter(edge -> EdgeViewerRegistry.contains(edge, pPoint))
+					.findFirst();
+		}
+		else
+		{
+			return storedEdge;
+		}
+		
+	}
+	
+	/**
+	 * Gets the smallest rectangle enclosing the diagram.
+	 * @param pDiagram The diagram to query
+	 * @return The bounding rectangle
+	 * @pre pDiagram != null
+	 */
+	public final Rectangle getBounds(Diagram pDiagram)
+	{
+		assert pDiagram != null;
+		Rectangle bounds = null;
+		for(Node node : pDiagram.rootNodes() )
+		{
+			if(bounds == null)
+			{
+				bounds = NodeViewerRegistry.getBounds(node);
+			}
+			else
+			{
+				bounds = bounds.add(NodeViewerRegistry.getBounds(node));
+			}
+		}
+		//When getBounds(pDiagram) is called to open an existing class diagram file,
+		//aEdgeStorage is initially empty and needs to be filled in order to compute the diagram bounds.
+		if (aEdgeStorage.isEmpty())
+		{
+			aLayouter.layout(pDiagram);
+		}
+		for(Edge edge : pDiagram.edges())
+		{
+			if(EdgePriority.isStoredEdge(edge)) 
+			{
+				bounds = bounds.add(STORED_EDGE_VIEWER.getBounds(edge));
+			}
+			else //For note edges (which are not stored in EdgeStorage):
+			{
+				bounds.add(EdgeViewerRegistry.getBounds(edge));
+			}
+		}
+		if(bounds == null )
+		{
+			return new Rectangle(0, 0, 0, 0);
+		}
+		else
+		{
+			return new Rectangle(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+		}
+	}
+	
+	/**
+	 * Draws selection handles on selected diagram elements.
+	 * @param pSelected the diagram element of interest
+	 * @param pContext the graphics context
+	 */
+	public void drawSelectionHandles(DiagramElement pSelected, GraphicsContext pContext)
+	{
+		if (pSelected instanceof Edge && EdgePriority.isStoredEdge((Edge) pSelected))
+		{
+				STORED_EDGE_VIEWER.drawSelectionHandles((Edge) pSelected, pContext);
+		}
+		else
+		{
+			ViewerUtils.drawSelectionHandles(pSelected, pContext);
+		}
+	}
+	
+	/**
+	 * Gets the EdgePath of pEdge from storage.
+	 * @param pEdge the edge of interest
+	 * @return the EdgePath describing the path of pEdge.
+	 * @pre aEdgeStorage.contains(pEdge)
+	 */
+	public EdgePath storedEdgePath(Edge pEdge)
+	{
+		assert aEdgeStorage.contains(pEdge);
+		return aEdgeStorage.getEdgePath(pEdge);
+				
+	}
+	
+	/**
+	 * Returns whether pEdge is present in aEdgeStorage.
+	 * @param pEdge the edge of interest
+	 * @return true if aEgdeStorage contains pEgde, false otherwise.
+	 * @pre pEdge != null;
+	 */
+	public boolean storageContains(Edge pEdge)
+	{
+		assert pEdge != null;
+		return aEdgeStorage.contains(pEdge);
+		
+	}
+	
+	/**
+	 * Returns a list of stored edges connected to pNode.
+	 * @param pNode the node of interest
+	 * @return a List of edges in storage which are connected to pNode.
+	 * @pre pNode != null;
+	 */
+	public List<Edge> storedEdgesConnectedTo(Node pNode)
+	{
+		assert pNode != null;
+		return aEdgeStorage.edgesConnectedTo(pNode);
+	}
+	
+	/**
+	 * Adds stores pEdge and pEdgePath in storage, or updates the EdgePath of pEdge if it is already present in storage.
+	 * @param pEdge the edge to store
+	 * @param pEdgePath the EdgePath of pEdge to be stored
+	 * @pre pEdge != null && pEdgePath != null
+	 */
+	public void store(Edge pEdge, EdgePath pEdgePath)
+	{
+		assert pEdge != null && pEdgePath != null;
+		aEdgeStorage.store(pEdge, pEdgePath);
+	}
+	
+	/**
+	 * Returns the edges in storage which are connected to both pEdge's start node and end node.
+	 * @param pEdge the Edge of interest
+	 * @return a list of edges in storage which are connected to both pEdge.getEnd() and pEdge.getStart()
+	 * @pre pEdge != null
+	 */
+	public List<Edge> storedEdgesWithSameNodes(Edge pEdge)
+	{
+		assert pEdge != null;
+		return aEdgeStorage.getEdgesWithSameNodes(pEdge);
+	}
+	
+	
+	/**
+	 * Returns whether pPoint is available as a connection point based on Egdes which are already in storage.
+	 * @param pPoint the Point of interest
+	 * @return false if aEdgeStorage contains an EdgePath which starts of ends at pPoint. True otherwise. 
+	 */
+	public boolean connectionPointAvailableInStorage(Point pPoint)
+	{
+		return aEdgeStorage.connectionPointIsAvailable(pPoint);
+	}
+	
+}

--- a/src/ca/mcgill/cs/jetuml/viewers/DiagramViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/DiagramViewer.java
@@ -48,7 +48,7 @@ public class DiagramViewer
 	 * @param pDiagram the diagram to draw.
 	 * @pre pDiagram != null && pGraphics != null.
 	 */
-	public final void draw(Diagram pDiagram, GraphicsContext pGraphics)
+	public void draw(Diagram pDiagram, GraphicsContext pGraphics)
 	{
 		assert pDiagram != null && pGraphics != null;
 		NodeViewerRegistry.activateNodeStorages();
@@ -57,7 +57,7 @@ public class DiagramViewer
 		NodeViewerRegistry.deactivateAndClearNodeStorages();
 	}
 	
-	private void drawNode(Node pNode, GraphicsContext pGraphics)
+	protected void drawNode(Node pNode, GraphicsContext pGraphics)
 	{
 		NodeViewerRegistry.draw(pNode, pGraphics);
 		pNode.getChildren().forEach(node -> drawNode(node, pGraphics));
@@ -71,7 +71,7 @@ public class DiagramViewer
 	 * @return An edge containing pPoint or Optional.empty() if no edge is under pPoint
 	 * @pre pDiagram != null && pPoint != null
 	 */
-	public static Optional<Edge> edgeAt(Diagram pDiagram, Point pPoint)
+	public Optional<Edge> edgeAt(Diagram pDiagram, Point pPoint)
 	{
 		assert pDiagram != null && pPoint != null;
 		return pDiagram.edges().stream()
@@ -143,7 +143,7 @@ public class DiagramViewer
 	 * @return The bounding rectangle
 	 * @pre pDiagram != null
 	 */
-	public static Rectangle getBounds(Diagram pDiagram)
+	public Rectangle getBounds(Diagram pDiagram)
 	{
 		assert pDiagram != null;
 		Rectangle bounds = null;

--- a/src/ca/mcgill/cs/jetuml/viewers/EdgePriority.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/EdgePriority.java
@@ -1,0 +1,106 @@
+package ca.mcgill.cs.jetuml.viewers;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+
+/**
+ * Represents the priority level for edges so that Layouter can lay out edges in a hierarchical order. 
+ * Arranged in decreasing order of priority (INHERITANCE has the highest priority)
+ */
+public enum EdgePriority 
+{
+	INHERITANCE, IMPLEMENTATION, AGGREGATION, COMPOSITION,
+	ASSOCIATION, DEPENDENCY, SELF_EDGE, OTHER;
+	
+	/**
+	 * Gets the EdgePriority of pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the EdgePriority associated with pEdge
+	 * @pre pEdge!=null
+	 */
+	public static EdgePriority priorityOf(Edge pEdge)
+	{
+		assert pEdge != null;
+		if (pEdge.getStart()!= null && pEdge.getEnd() != null && pEdge.getStart().equals(pEdge.getEnd()))
+		{
+			return EdgePriority.SELF_EDGE;
+		}
+		else if (pEdge instanceof GeneralizationEdge)
+		{
+			if (((GeneralizationEdge) pEdge).getType() == GeneralizationEdge.Type.Inheritance) 
+			{
+				return EdgePriority.INHERITANCE;
+			}
+			else
+			{
+				return EdgePriority.IMPLEMENTATION;
+			}
+		}
+		else if (pEdge instanceof AggregationEdge)
+		{
+			if (((AggregationEdge) pEdge).getType() == AggregationEdge.Type.Aggregation)
+			{
+				return EdgePriority.AGGREGATION;
+			}
+			else
+			{
+				return EdgePriority.COMPOSITION;
+			}
+		}
+		else if (pEdge instanceof AssociationEdge)
+		{
+			return EdgePriority.ASSOCIATION;
+		}
+		else if (pEdge instanceof DependencyEdge)
+		{
+			return EdgePriority.DEPENDENCY;
+		}
+		else
+		{
+			return EdgePriority.OTHER;
+		}
+	}
+	
+	/**
+	 * Returns whether pPriority describes a segmented edge.
+	 * Since Layouter plans the paths of self-edges separately, self-edges are not segmented by this method. 
+	 * @param pPriority the EdgePriority level of interest
+	 * @return true if the pPriority is the priority for a segmented edge, false otherwise
+	 * @pre pPriority!=null;
+	 */
+	public static boolean isSegmented(EdgePriority pPriority)
+	{
+		assert pPriority != null;
+		if (pPriority == EdgePriority.INHERITANCE || pPriority == EdgePriority.IMPLEMENTATION)
+		{
+			return true;
+		}
+		else 
+		{
+			return pPriority == EdgePriority.AGGREGATION || pPriority == EdgePriority.COMPOSITION || 
+					pPriority == EdgePriority.ASSOCIATION;    	
+		}
+	}
+	
+	/**
+	 * Returns whether pEdge is segmented.
+	 * @param pEdge the edge of interest
+	 * @return true if pEdge is segmented, false otherwise.
+	 */
+	public static boolean isSegmented(Edge pEdge)
+	{
+		return isSegmented(priorityOf(pEdge));
+	}
+	
+	/**
+	 * Returns whether pEdge is a  class diagram Edge which can be stored in EdgeStorage by Layouter. 
+	 * @param pEdge the edge of interest
+	 * @return true if pEdge should be stored in EdgeStorage, false otherwise. 
+	 */
+	public static boolean isStoredEdge(Edge pEdge)
+	{
+		return priorityOf(pEdge)!= OTHER;
+	}
+}

--- a/src/ca/mcgill/cs/jetuml/viewers/ImageCreator.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/ImageCreator.java
@@ -28,7 +28,7 @@ import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.image.Image;
 import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
-
+import static ca.mcgill.cs.jetuml.diagram.DiagramType.viewerFor;
 /**
  * Utility class to create icons that are drawn
  * using graphic primitives.
@@ -49,7 +49,7 @@ public final class ImageCreator
 	public static Image createImage(Diagram pDiagram)
 	{
 		assert pDiagram != null;
-		Rectangle bounds = DiagramViewer.getBounds(pDiagram);
+		Rectangle bounds = viewerFor(pDiagram).getBounds(pDiagram);
 		Canvas canvas = new Canvas(bounds.getWidth() + DIAGRAM_PADDING * 2, 
 				bounds.getHeight() + DIAGRAM_PADDING *2);
 		GraphicsContext context = canvas.getGraphicsContext2D();

--- a/src/ca/mcgill/cs/jetuml/viewers/Layouter.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/Layouter.java
@@ -1,0 +1,1335 @@
+package ca.mcgill.cs.jetuml.viewers;
+
+import static ca.mcgill.cs.jetuml.viewers.EdgePriority.priorityOf;
+import static ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry.getBounds;
+import static java.util.stream.Collectors.toList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ThreeLabelEdge;
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Line;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.edges.NodeIndex;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+
+/**
+ * Plans and stores the paths for edges based on the position of stored edges and nodes 
+ * to make the diagram more clean and readable.
+*/
+public class Layouter 
+{
+	private static final int TEN_PIXELS = 10;
+	
+	/**
+	 * Uses positional information of nodes and stored edges to layout and store 
+	 * the EdgePaths of edges in pDiagram.
+	 * @param pDiagram the diagram of interest
+	 * @pre pDiagram.getType() == DiagramType.CLASS
+	 */
+	public void layout(Diagram pDiagram)
+	{
+		assert pDiagram.getType() == DiagramType.CLASS;
+		layoutSegmentedEdges(pDiagram, EdgePriority.INHERITANCE);	
+		layoutSegmentedEdges(pDiagram, EdgePriority.IMPLEMENTATION);
+		layoutSegmentedEdges(pDiagram, EdgePriority.AGGREGATION);
+		layoutSegmentedEdges(pDiagram, EdgePriority.COMPOSITION);
+		layoutSegmentedEdges(pDiagram, EdgePriority.ASSOCIATION);
+		layoutDependencyEdges(pDiagram);
+		layoutSelfEdges(pDiagram);
+	}
+	
+
+
+	/**
+	 * Plans the EdgePaths for all segmented edges in pDiagram with EdgePriority pEdgePriority.
+	 * @param pDiagram the diagram to layout
+	 * @param pEdgePriority the edge priority level 
+	 * @pre pDiagram.getType() == DiagramType.CLASS
+	 * @pre EdgePriority.isSegmented(pEdgePriority)
+	 */
+	private void layoutSegmentedEdges(Diagram pDiagram, EdgePriority pEdgePriority)
+	{
+		assert pDiagram.getType() == DiagramType.CLASS;
+		assert EdgePriority.isSegmented(pEdgePriority);
+		List<Edge> edgesToProcess = pDiagram.edges().stream()
+				.filter(edge -> priorityOf(edge) == pEdgePriority)
+				.sorted(Comparator.comparing(edge -> edge.getStart().position().getX()))
+				.collect(toList());
+				
+		while (!edgesToProcess.isEmpty())
+		{
+			Edge currentEdge = edgesToProcess.get(0);
+			Direction edgeDirection = attachedSide(currentEdge, currentEdge.getStart());
+			//Get all the edges which will merge with the start or end of currentEdge
+			List<Edge> edgesToMergeStart = getEdgesToMergeStart(currentEdge, edgesToProcess);
+			List<Edge> edgesToMergeEnd = getEdgesToMergeEnd(currentEdge, edgesToProcess);	
+			//Determine if currendEdge should merge with other edges at its start node or end node
+			if (!edgesToMergeStart.isEmpty())
+			{ 	
+				edgesToMergeStart.add(currentEdge);
+				edgesToProcess.removeAll(edgesToMergeStart);
+				storeMergedStartEdges(edgeDirection, edgesToMergeStart, pDiagram);
+			}
+			else
+			{
+				edgesToMergeEnd.add(currentEdge);
+				edgesToProcess.removeAll(edgesToMergeEnd);
+				storeMergedEndEdges(edgeDirection, edgesToMergeEnd, pDiagram);
+			}
+		}
+	}
+	
+	
+	/**
+	 * Plans the EdgePaths for Dependency Edges.
+	 * @param pDiagram the diagram of interest
+	 * @pre pDiagram.getType() == DiagramType.CLASS;
+	 */
+	private void layoutDependencyEdges(Diagram pDiagram)
+	{
+		assert pDiagram.getType() == DiagramType.CLASS;
+		for (Edge edge : pDiagram.edges())
+		{
+			if (priorityOf(edge)==EdgePriority.DEPENDENCY)
+			{   //Determine the start and end connection points
+				Direction attachedEndSide = attachedSide(edge, edge.getEnd());
+				Point startPoint = getConnectionPoint(edge.getStart(), edge, attachedEndSide.mirrored());
+				Point endPoint = getConnectionPoint(edge.getEnd(), edge, attachedEndSide);
+				//Store an EdgePath from startPoint to endPoint
+				classDiagramViewerFor(edge).store(edge, new EdgePath(startPoint, endPoint));
+			}
+		}	
+	}
+	
+	/**
+	 * Plans the EdgePaths for self-edges in pDiagram.
+	 * @param pDiagram the diagram of interest
+	 * @pre pDiagram.getType() == DiagramType.CLASS;
+	 */
+	private void layoutSelfEdges(Diagram pDiagram)
+	{
+		assert pDiagram.getType() == DiagramType.CLASS;
+		List<Edge> selfEdges = pDiagram.edges().stream()
+			.filter(edge -> priorityOf(edge) == EdgePriority.SELF_EDGE)
+			.collect(toList());
+		for (Edge edge : selfEdges)
+		{
+			//Determine the corner where the self-edge should be placed
+			NodeCorner corner = getSelfEdgeCorner(edge);
+			//Build a self-edge EdgePath at the corner and store it
+			EdgePath path = buildSelfEdge(edge, corner);
+			classDiagramViewerFor(edge).store(edge, path);
+		}
+	}
+	
+	/**
+	 * Gets the node corner where the self-edge pEdge should be placed. If no corners are available, returns TOP_RIGHT. 
+	 * @param pEdge the self-edge of interest
+	 * @return the first available corner on the node, starting with TOP_RIGHT and moving counter-clockwise.
+	 * @pre priorityOf(pEdge) == EdgePriority.SELF_EDGE
+	 */
+	private NodeCorner getSelfEdgeCorner(Edge pEdge)
+	{
+		assert priorityOf(pEdge) == EdgePriority.SELF_EDGE;
+		for (NodeCorner corner : NodeCorner.values())
+		{	//Get a 2D array of [startPoint, endPoint] for a self edge at the corner
+			Point[] points = NodeCorner.toPoints(corner, pEdge.getEnd());
+			//Return the first corner with available start and end points
+			if (classDiagramViewerFor(pEdge).connectionPointAvailableInStorage(points[0]) && 
+					classDiagramViewerFor(pEdge).connectionPointAvailableInStorage(points[1]))
+			{
+				return corner;
+			}
+		}
+		//if no corners are available, the top right corner will be used.
+		return NodeCorner.TOP_RIGHT;
+	}
+	
+	/**
+	 * Builds an EdgePath for a self-edge pEdge, on the pCorner of pEdge's node.
+	 * @param pEdge the edge of interest
+	 * @param pCorner the corner of a node where the self edge should be
+	 * @return the EdgePath for pEdge, beginning on the North or South side of a node, ending on the East or West side of the node. 
+	 * @pre EdgePriority.priorityOf(pEdge) == EdgePriority.SELF_EDGE
+	 * @pre pCorner != null
+	 */
+	private EdgePath buildSelfEdge(Edge pEdge, NodeCorner pCorner)
+	{
+		assert priorityOf(pEdge) == EdgePriority.SELF_EDGE;
+		assert pCorner != null;
+		Point[] connectionPoints = NodeCorner.toPoints(pCorner, pEdge.getEnd());
+		Point startPoint = connectionPoints[0];
+		Point endPoint = connectionPoints[1];
+		Point firstBend;
+		Point middleBend;
+		Point lastBend;
+		//determine location of first bend: either 20px above or 20px below the start point
+		if (NodeCorner.horizontalSide(pCorner) == Direction.NORTH)
+		{
+			firstBend = new Point(startPoint.getX(), startPoint.getY() - (2 * TEN_PIXELS)); 
+		}
+		else
+		{
+			firstBend = new Point(startPoint.getX(), startPoint.getY() + (2 * TEN_PIXELS)); 
+		}
+		//determine location of middle and last bends
+		if (NodeCorner.verticalSide(pCorner) == Direction.EAST)
+		{
+			middleBend = new Point(firstBend.getX() + (4 * TEN_PIXELS), firstBend.getY());
+			lastBend = new Point(endPoint.getX() + (2 * TEN_PIXELS), endPoint.getY());
+		}
+		else
+		{
+			middleBend = new Point(firstBend.getX() - (4 * TEN_PIXELS), firstBend.getY());
+			lastBend = new Point(endPoint.getX() - (2 * TEN_PIXELS), endPoint.getY());
+		}
+		return new EdgePath(startPoint, firstBend, middleBend, lastBend, endPoint);
+	}
+
+	
+	/**
+	 * Builds and stores the EdgePaths for edges in pEdgesToMergeEnd, so they merge at a common end point.
+	 * @param pDirection the trajectory of the edges in pEdgesToMergeEnd (the direction of the first segment of the edges)
+	 * @param pEdgesToMergeEnd a list of edges whose ends should be merged
+	 * @param pDiagram the diagram
+	 * @pre pDirection.isCardinal()
+	 * @pre pEdgesToMergeEnd.size() > 0
+	 * @pre pDiagram.getType() == DiagramType.CLASS
+	 */
+	private void storeMergedEndEdges(Direction pDirection, List<Edge> pEdgesToMergeEnd, Diagram pDiagram)
+	{
+		assert pDirection.isCardinal();
+		assert pEdgesToMergeEnd.size() > 0;
+		assert pDiagram.getType() == DiagramType.CLASS;
+		//Merged edges will share a common end point
+		Point sharedEndPoint = getConnectionPoint(pEdgesToMergeEnd.get(0).getEnd(), pEdgesToMergeEnd.get(0), pDirection.mirrored());
+		//get the individual start points for each edge
+		Map<Edge, Point> startPoints = new HashMap<Edge, Point>();
+		for (Edge e : pEdgesToMergeEnd)
+		{
+			startPoints.put(e, getConnectionPoint(e.getStart(), e, pDirection));
+		}
+		//Determine the position of the shared middle segment
+		Point closestStartPoint = getClosestPoint(startPoints.values(), pDirection);
+		int midLineCoordinate;
+		if (pDirection == Direction.NORTH || pDirection == Direction.SOUTH)
+		{
+			midLineCoordinate = getHorizontalMidLine(closestStartPoint, sharedEndPoint, pDirection, pEdgesToMergeEnd.get(0));
+		}
+		else
+		{
+			midLineCoordinate = getVerticalMidLine(closestStartPoint, sharedEndPoint, pDirection, pEdgesToMergeEnd.get(0));
+		}
+		//Build and store each edge's EdgePath
+		for (Edge edge : pEdgesToMergeEnd)
+		{
+			EdgePath path = buildSegmentedEdgePath(pDirection, startPoints.get(edge), midLineCoordinate, sharedEndPoint);
+			classDiagramViewerFor(pEdgesToMergeEnd.get(0)).store(edge, path);
+		}
+	}
+	
+	
+	/**
+	 * Builds and stores the EdgePaths for edges in pEdgesToMergeStart so that they share a common start point.
+	 * @param pDirection the trajectory of the edges in pEdgesToMmergeStart (the direction of the first segment of the edges)
+	 * @param pEdgesToMergeStart a list of edges which should me merged at their start points
+	 * @param pDiagram the class diagram 
+	 * @pre pDirection.isCardinal()
+	 * @pre pEdgesToMergeStart.size() > 0
+	 * @pre pDiagram.getType() == DiagramType.CLASS
+	 */
+	private void storeMergedStartEdges(Direction pDirection, List<Edge> pEdgesToMergeStart, Diagram pDiagram)
+	{
+		assert pDirection.isCardinal();
+		assert pEdgesToMergeStart.size() > 0;
+		//Get the shared start point for all pEdgesToMerge
+		Point startPoint = getConnectionPoint(pEdgesToMergeStart.get(0).getStart(), pEdgesToMergeStart.get(0), pDirection);
+		//Get the individual end points for each edge
+		Map<Edge, Point> endPoints = new HashMap<Edge, Point>();
+		for (Edge edge : pEdgesToMergeStart)
+		{
+			endPoints.put(edge, getConnectionPoint(edge.getEnd(), edge, pDirection.mirrored()));
+		}
+		//Determine the X or Y coordinate of the middle segment for the edges:
+		//The default position of the merged middle segment is halfway between startPoint and closestEndPoint:
+		Point closestEndPoint = getClosestPoint(endPoints.values(), pDirection.mirrored());
+		int midLineCoordinate;
+		if (pDirection == Direction.NORTH || pDirection == Direction.SOUTH)
+		{
+			midLineCoordinate = getHorizontalMidLine(closestEndPoint, startPoint, pDirection, 
+					pEdgesToMergeStart.get(0));
+		}
+		else
+		{
+			midLineCoordinate = getVerticalMidLine(closestEndPoint, startPoint, pDirection, 
+					pEdgesToMergeStart.get(0));
+		}
+		//Build and store each edge's EdgePath
+		for (Edge edge : pEdgesToMergeStart)
+		{
+			EdgePath path = buildSegmentedEdgePath(pDirection, startPoint, midLineCoordinate, endPoints.get(edge));
+			classDiagramViewerFor(pEdgesToMergeStart.get(0)).store(edge, path);
+		}
+	}
+	
+	
+	/**
+	 * Creates a segmented EdgePath using pStart and pEnd as start and end points (respectively)
+	 * and pMidLine as an X or Y coordinate of the middle segment. 
+	 * @param pEdgeDirection the direction describing the trajectory of pEdge
+	 * @param pStart the start point of pEdge
+	 * @param pMidLine an integer representing an X or Y coordinate of the middle segment
+	 * @param pEnd the end point of pEdge
+	 * @return a EdgePath consisting of pStart, 2 middle points connecting the middle segment, and pEnd
+	 * @pre pEdgeDirection.isCardinal()
+	 * @pre pStart != null && pEnd != null
+	 * @pre pMidLine >= 0
+	 */
+	private EdgePath buildSegmentedEdgePath(Direction pEdgeDirection, Point pStart, int pMidLine, Point pEnd)
+	{
+		assert pEdgeDirection.isCardinal();
+		assert pStart != null && pEnd != null;
+		assert pMidLine >= 0;
+		Point firstMiddlePoint;
+		Point secondMiddlePoint;
+		if (pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH)
+		{
+			//Then the mid-point coordinate is a Y-coordinate
+			firstMiddlePoint = new Point(pStart.getX(), pMidLine);
+			secondMiddlePoint = new Point(pEnd.getX(), pMidLine);
+		}
+		else //East or West
+		{	//Then the mid-point coordinate is a X-coordinate
+			firstMiddlePoint = new Point(pMidLine, pStart.getY());
+			secondMiddlePoint = new Point(pMidLine, pEnd.getY());
+		}
+		return new EdgePath(pStart, firstMiddlePoint, secondMiddlePoint, pEnd);
+	}
+	
+	
+	/**
+	 * Gets the edges which should merge to share a common end point with pEdge.
+	 * @param pEdge the edge of interest
+	 * @param pEdges a list of edges in the diagram
+	 * @return a list containing the edges which should merge with pEdge (not including pEdge itself).
+	 * @pre pEdge != null
+	 * @pre pEdges != null
+	 */
+	private List<Edge> getEdgesToMergeEnd(Edge pEdge, List<Edge> pEdges)
+	{
+		assert pEdge != null && pEdges != null;
+		return pEdges.stream()
+				.filter(edge -> edge.getEnd() == pEdge.getEnd())
+				.filter(edge -> priorityOf(edge) == priorityOf(pEdge))
+				.filter(edge -> attachedSide(edge, edge.getEnd()) == attachedSide(pEdge, pEdge.getEnd())) 
+				.filter(edge -> noConflictingEndLabels(edge, pEdge))
+				.filter(edge -> noOtherEdgesBetween(edge, pEdge, pEdge.getEnd()))
+				.filter(edge -> !edge.equals(pEdge))
+				.collect(toList());		
+	}
+	
+	/**
+	 * Gets the edges which should merge to share a common start point with pEdge.
+	 * @param pEdge the edge of interest
+	 * @param pEdges a list of edges in the diagram
+	 * @return a list containing the edges which should merge with pEdge (not including pEdge itself).
+	 * @pre pEdge != null
+	 * @pre pEdges != null
+	 */
+	private List<Edge> getEdgesToMergeStart(Edge pEdge, List<Edge> pEdges)
+	{
+		assert pEdge != null && pEdges != null;
+		return pEdges.stream()
+			.filter(edge -> edge.getStart().equals(pEdge.getStart()))
+			.filter(edge -> priorityOf(edge) == priorityOf(pEdge))
+			.filter(edge -> attachedSide(edge, edge.getStart()) == attachedSide(pEdge, pEdge.getStart()))
+			.filter(edge -> noOtherEdgesBetween(edge, pEdge, pEdge.getStart()))
+			.filter(edge -> noConflictingStartLabels(edge, pEdge))
+			.filter(edge -> !edge.equals(pEdge))
+			.collect(toList());
+	}
+	
+	/**
+	 * Gets the y-coordinate of the horizontal middle segment of pEdge.
+	 * @param pStart the start point for pEdge
+	 * @param pEnd the end point for pEdge
+	 * @param pEdgeDirection the trajectory of pEdge, either North or South
+	 * @param pEdge the segmented edge of interest
+	 * @return an integer representing a y-coordinate of the middle segment of pEdge
+	 * @pre pDirection == Direction.NORTH || pDirection == Direction.SOUTH
+	 * @pre EdgePriority.isSegmented(pEdge)
+	 * @pre pStart != null && pEnd != null
+	 */
+	private int getHorizontalMidLine(Point pStart, Point pEnd, Direction pEdgeDirection, Edge pEdge)
+	{
+		assert pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH;
+		assert EdgePriority.isSegmented(pEdge);
+		assert pStart != null && pEnd != null;
+		//Check for any edge in storage which is attached to pEdge's start and end nodes
+		// "Shared-node edges" require a different layout strategy:
+		List<Edge> storedEdgesWithSameNodes = classDiagramViewerFor(pEdge).storedEdgesWithSameNodes(pEdge);
+		if (!storedEdgesWithSameNodes.isEmpty())
+		{
+			return horizontalMidlineForSharedNodeEdges(storedEdgesWithSameNodes.get(0), pEdge, pEdgeDirection);
+		}
+		//Otherwise, find the closest edge which conflicts with pEdge
+		Optional<Edge> closestStoredEdge = closestConflictingHorizontalSegment(pEdgeDirection, pEdge);
+		if (closestStoredEdge.isEmpty())
+		{
+			//If there are no conflicting segments, return the y-coordinate equidistant between the start and end points
+			return pEnd.getY() + ((pStart.getY() - pEnd.getY()) / 2);
+		}
+		else
+		{	//Return a y-coordinate either 10px above or 10px below the horizontal middle segment of closestStoredEdge
+			return adjacentHorizontalMidLine(closestStoredEdge.get(), pEdge, pEdgeDirection);	
+		}
+	}
+	
+	/**
+	 * Gets the x-coordinate of the vertical middle segment of pEdge.
+	 * @param pStart the start point of pEdge
+	 * @param pEnd the end point of pEdge
+	 * @param pEdgeDirection the direction of pEdge (the direction of the first segment of pEdge).
+	 * @param pEdge the edge of interest
+	 * @return an integer representing the x-coordinate for the vertical middle segment of pEdge.
+	 * @pre pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST
+	 * @pre EdgePriority.isSegmented(pEdge)
+	 * @pre pStart != null && pEnd != null
+	 */
+	private int getVerticalMidLine(Point pStart, Point pEnd, Direction pEdgeDirection, Edge pEdge)
+	{
+		assert pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST;
+		assert EdgePriority.isSegmented(pEdge);
+		assert pStart != null && pEnd != null;
+		//Check for any edge in storage which shares the same 2 nodes as pEdge: 
+		List<Edge> storedEdgesWithSameNodes = classDiagramViewerFor(pEdge).storedEdgesWithSameNodes(pEdge);
+		if (!storedEdgesWithSameNodes.isEmpty())
+		{
+			//"Shared-node edges" require a different layout strategy
+			return verticalMidlineForSharedNodeEdges(storedEdgesWithSameNodes.get(0), pEdge, pEdgeDirection);
+		}
+		//Otherwise, find the closest edge which conflicts with pEdge
+		Optional<Edge> closestStoredEdge = closestConflictingVerticalSegment(pEdgeDirection, pEdge);
+		if (closestStoredEdge.isEmpty())
+		{
+			//If no stored edges conflict with pEdge then return the x-coordinate in between the start and end points
+			return pEnd.getX() + ((pStart.getX() - pEnd.getX()) / 2);
+		}
+		else
+		{	//Return an x-coordinate either 10px to the left or 10px to the right of closestStoredEdge
+			return adjacentVerticalMidLine(closestStoredEdge.get(), pEdge, pEdgeDirection);
+		}
+	}
+	
+	/**
+	 * Gets the y-coordinate of the horizontal middle segment of pNewEdge, so that it avoids overlapping with 
+	 * pEdgeWithSameNodes, which is already in storage.
+	 * @param pEdgeWithSameNodes an edge in storage which shares the same 2 connected nodes as pNewEdge. 
+	 * @param pNewEdge the segmented edge whose middle segment we want
+	 * @param pEdgeDirection the direction of pEdge (the direction of the first segment of pEdge). 
+	 * @return an integer describing the y-coordinate of the middle segment of pEdge, so that pEdge and pEdgeWithSameNodes do not overlap.
+	 * @pre pEdgeWithSameNodes is present in storage
+	 * @pre pEdgeWithSameNodes and pEdge both share the same 2 attached nodes.
+	 * @pre pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH
+	 */
+	private int horizontalMidlineForSharedNodeEdges(Edge pEdgeWithSameNodes, Edge pNewEdge, Direction pEdgeDirection)
+	{
+		assert classDiagramViewerFor(pEdgeWithSameNodes).storageContains(pEdgeWithSameNodes);
+		assert pEdgeWithSameNodes.getStart() == pNewEdge.getStart() || pEdgeWithSameNodes.getStart() == pNewEdge.getEnd();
+		assert pEdgeWithSameNodes.getEnd() == pNewEdge.getStart() || pEdgeWithSameNodes.getEnd() == pNewEdge.getEnd();
+		assert pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH;
+		if (pEdgeDirection == Direction.NORTH)
+		{	
+			return getStoredEdgePath(pEdgeWithSameNodes).getPointByIndex(1).getY() - TEN_PIXELS;
+		}
+		else //pEdgeDirection == Direction.SOUTH
+		{
+			return getStoredEdgePath(pEdgeWithSameNodes).getPointByIndex(1).getY() + TEN_PIXELS;
+		}
+	}
+	
+	/**
+	 * Gets the x-coordinate of the vertical middle segment of pNewEdge, so that it avoids overlapping with 
+	 * pEdgeWithSameNodes, which is already in storage.
+	 * @param pEdgeWithSameNodes an edge in storage which shares the same 2 connected nodes as pNewEdge. 
+	 * @param pNewEdge the edge whose EdgePath we want to plan
+	 * @param pEdgeDirection the direction of pEdge (the direction of the first segment of pEdge). 
+	 * @return The x-coordinate of the middle segment of pEdge, so that pEdge and pEdgeWithSameNodes do not overlap.
+	 * @pre pEdgeWithSameNodes is present in storage
+	 * @pre pEdgeWithSameNodes and pEdge both share the same 2 attached nodes.
+	 * @pre pEdgeDirection == Direction.WEST || pEdgeDirection == Direction.EAST
+	 */
+	private int verticalMidlineForSharedNodeEdges(Edge pEdgeWithSameNodes, Edge pNewEdge, Direction pEdgeDirection) 
+	{
+		assert classDiagramViewerFor(pEdgeWithSameNodes).storageContains(pEdgeWithSameNodes);
+		assert pEdgeWithSameNodes.getStart() == pNewEdge.getStart() || pEdgeWithSameNodes.getStart() == pNewEdge.getEnd();
+		assert pEdgeWithSameNodes.getEnd() == pNewEdge.getStart() || pEdgeWithSameNodes.getEnd() == pNewEdge.getEnd();
+		assert pEdgeDirection == Direction.WEST || pEdgeDirection == Direction.EAST;
+		if (pEdgeDirection == Direction.WEST)
+		{
+			return getStoredEdgePath(pEdgeWithSameNodes).getPointByIndex(1).getX() - TEN_PIXELS;
+		}
+		else
+		{
+			return getStoredEdgePath(pEdgeWithSameNodes).getPointByIndex(1).getX() + TEN_PIXELS;
+		}
+	}
+	
+	
+	/**
+	 * Gets the closest Edge to pEdge.getEnd() (or pEdge.getStart() for AggregationEdges) which might interfere with the position 
+	 * of the horizontal middle segment of pEdge. Considers all stored, segmented edges which are attached to either of pEdge's nodes and 
+	 * could conflict with pEdge. 
+	 * @param pEdgeDirection the direction describing the trajectory of pEdge (the direction of the first segment of pEdge)
+	 * @param pEdge the edge of interest
+	 * @return the closest Edge conflicting with the horizontal middle segment of pEdge, or Optional.empty() if there are no conflicting edges.
+	 * @pre pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH
+	 */
+	private Optional<Edge> closestConflictingHorizontalSegment(Direction pEdgeDirection, Edge pEdge)
+	{
+		assert pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH;
+		//Consider all edges connected to pEdge.getEnd() which are in the way of pEdge
+		List<Edge> conflictingEdges = storedConflictingEdges(pEdgeDirection.mirrored(), pEdge.getEnd(), pEdge);	
+		//also consider edges which are connected to pEdge.getStart() which are in the way of pEdge
+		conflictingEdges.addAll(storedConflictingEdges(pEdgeDirection, pEdge.getStart(), pEdge));
+		if (conflictingEdges.isEmpty())
+		{
+			return Optional.empty();
+		}
+		else 
+		{	//For Aggregation/Composition edges: return the Edge with the middle segment which is closest to pEdge's start node
+			if (pEdge instanceof AggregationEdge)
+			{
+				return conflictingEdges.stream()
+						.min(Comparator.comparing(edge -> verticalDistanceToNode(pEdge.getStart(), edge, pEdgeDirection)));
+			}
+			else
+			{  //For all other segmented edges: return the Edge with the middle segment which is closest to pEdge's end node
+				return conflictingEdges.stream()
+						.min(Comparator.comparing(edge -> verticalDistanceToNode(pEdge.getEnd(), edge, pEdgeDirection)));
+			}
+		}
+	}
+	
+	/**
+	 * Gets the closest Edge to pEdge.getEnd() (pEdge.getStart() for AggregationEdges) which might interfere with the position of 
+	 * the vertical middle segment of pEdge. Considers all segmented edges which are attached to both pEdge.getStart() and pEdge.getEnd(), 
+	 * and could conflict with pEdge. 
+	 * @param pEdgeDirection the direction describing the trajectory of pEdge (the direction of the first segment of pEdge)
+	 * @param pEdge the edge of interest
+	 * @return the closest Edge conflicting with the vertical middle segment of pEdge, or Optional.empty() if there are no conflicting edges.
+	 * @pre pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST
+	 * @pre EdgePriority.isSegmented(pEdge)
+	 */
+	private Optional<Edge> closestConflictingVerticalSegment(Direction pEdgeDirection, Edge pEdge) 
+	{
+		assert pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST;
+		assert EdgePriority.isSegmented(pEdge);
+		//Get all edges connected to pEdge's end node which could conflict with pEdge's middle segment position
+		List<Edge> conflictingEdges = storedConflictingEdges(pEdgeDirection.mirrored(), pEdge.getEnd(), pEdge);	
+		//Also consider edges connected to pEdge's start node which could conflict with pEdge's middle segment
+		conflictingEdges.addAll(storedConflictingEdges(pEdgeDirection, pEdge.getStart(), pEdge));
+		if (conflictingEdges.isEmpty())
+		{
+			return Optional.empty();
+		}
+		else 
+		{	//for AggregationEdges: return the Edge with the middle segment which is closest to pEdge.getStart()
+			if (pEdge instanceof AggregationEdge)
+			{
+				return conflictingEdges.stream()
+						.min(Comparator.comparing(edge -> horizontalDistanceToNode(pEdge.getStart(), edge, pEdgeDirection)));
+			}
+			else
+			{	//For all other edges: return the Edge with the middle segment which is closest to pEdge.getEnd()
+				return conflictingEdges.stream()
+						.min(Comparator.comparing(edge -> horizontalDistanceToNode(pEdge.getEnd(), edge, pEdgeDirection)));
+			}
+		}
+	}
+	
+	
+	/**
+	 * Gets the y-coordinate for the horizontal middle segment of pEdge based on the position of pClosestStoredEdge. 
+	 * @param pClosestStoredEdge the closest edge which conflicts with pEdge. 
+	 * @param pEdge the edge of interest
+	 * @param pEdgeDirection the direction describing the trajectory of pEdge (the direction of the first segment of pEdge)
+	 * @return the y-coordinate for the middle segment of pEdge: either 10px below pClosestStoredEdge or 10px above pClosestStoredEdge 
+	 * @pre classDiagramViewerFor(pEdge).storageContains(pClosestStoredEdge)
+	 * @pre EdgePriority.isSegmented(pEdge)
+	 * @pre pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH
+	 */
+	private int adjacentHorizontalMidLine(Edge pClosestStoredEdge, Edge pEdge, Direction pEdgeDirection)
+	{
+		assert classDiagramViewerFor(pEdge).storageContains(pClosestStoredEdge);
+		assert EdgePriority.isSegmented(pEdge);
+		assert pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH;
+		Node commonNode = getSharedNode(pClosestStoredEdge, pEdge);
+		if (pEdgeDirection == Direction.NORTH)
+		{
+			if (isOutgoingEdge(pEdge, commonNode))
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getY() + TEN_PIXELS;
+			}
+			else
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getY() - TEN_PIXELS;
+			}
+		}
+		else //Direction is SOUTH
+		{
+			if (isOutgoingEdge(pEdge, commonNode))
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getY() - TEN_PIXELS;
+			}
+			else
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getY() + TEN_PIXELS;
+			}
+		}
+	}
+	
+	
+	/**
+	 * Gets the x-coordinate for the vertical middle segment of pEdge based on the position of pClosestStoredEdge. 
+	 * @param pClosestStoredEdge the closest edge to pNode which conflicts with pEdge. 
+	 * @param pEdge the edge of interest
+	 * @param pEdgeDirection the direction describing the trajectory of pEdge (the direction of the first segment of pEdge).
+	 * @return the x-coordinate for the middle segment of pEdge, 
+	 * so that it is either 10px to the right of pClosestStoredEdge, or 10px to the left.
+	 * @pre pClosestStoredEdge is present in the diagram's EdgeStorage
+	 * @pre EdgePriority.isSegmented(pEdge)
+	 * @pre pEdgeDirection == Direction.WEST || pEdgeDirection == Direction.EAST
+	 */
+	private int adjacentVerticalMidLine(Edge pClosestStoredEdge, Edge pEdge, Direction pEdgeDirection) 
+	{
+		assert classDiagramViewerFor(pEdge).storageContains(pClosestStoredEdge);
+		assert EdgePriority.isSegmented(pEdge);
+		assert pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST;
+		Node commonNode = getSharedNode(pClosestStoredEdge, pEdge);
+		if (pEdgeDirection == Direction.WEST)
+		{
+			if (isOutgoingEdge(pEdge, commonNode))
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getX() + TEN_PIXELS;
+			}
+			else
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getX() - TEN_PIXELS;
+			}
+		}
+		else //Direction is EAST
+		{
+			if (isOutgoingEdge(pEdge, commonNode))
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getX() - TEN_PIXELS;
+			}
+			else
+			{
+				return getStoredEdgePath(pClosestStoredEdge).getPointByIndex(1).getX() + TEN_PIXELS;
+			}
+		}
+	}
+
+	
+	/**
+	 * Gets the node which pEdgeA and pEdgeB are both attached to.
+	 * @param pEdgeA an edge in the diagram
+	 * @param pEdgeB another edge in the diagram
+	 * @return the Node which pEdgeA and pEdgeB are both connected to.
+	 * @pre pEdgeA and pEdgeB have an attached node in common
+	 */
+	private Node getSharedNode(Edge pEdgeA, Edge pEdgeB)
+	{
+		assert pEdgeA.getStart() == pEdgeB.getStart() || pEdgeA.getStart() == pEdgeB.getEnd() ||
+				pEdgeA.getEnd() == pEdgeB.getStart() || pEdgeA.getEnd() == pEdgeB.getEnd();
+		if (pEdgeA.getStart().equals(pEdgeB.getStart()) || pEdgeA.getStart().equals(pEdgeB.getEnd()))
+		{
+			return pEdgeA.getStart();
+		}
+		else
+		{			
+			return pEdgeA.getEnd();
+		}
+	}
+	
+	/**
+	 * Gets all edges currently in storage which are connected to the pNodeFace side of pNode
+	 * with the same index sign (-1 or +1) as pEdge. These edges may conflict with the default placement 
+	 * of pEdge, so their EdgePaths need to be considered when planning the EdgePath of pEdge. 
+	 * @param pNodeFace the face of pNode on which pEdge is attached
+	 * @param pNode the node of interest which pEdge is attached to
+	 * @param pEdge the edge of interest
+	 * @return a list of edges which could conflict with the default EdgePath of pEdge.
+	 * @pre pNodeFace.isCardinal() 
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 */
+	private List<Edge> storedConflictingEdges(Direction pNodeFace, Node pNode, Edge pEdge)
+	{
+		assert pNodeFace.isCardinal();
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		return classDiagramViewerFor(pEdge).storedEdgesConnectedTo(pNode).stream()
+			.filter(edge -> attachedSideFromStorage(edge, pNode) == pNodeFace)
+			.filter(edge -> EdgePriority.isSegmented(edge))
+			.filter(edge -> getIndexSign(edge, pNode, pNodeFace) == getIndexSign(pEdge, pNode, pNodeFace))
+			.filter(edge -> !edge.equals(pEdge))
+			.collect(toList());
+	}
+	
+	/**
+	 * Uses EdgeStorage to get the cardinal Direction describing the face of pNode on which a stored edge pEdge is attached.
+	 * @param pEdge the edge of interest
+	 * @param pNode the node of interest which PEdge is attached to
+	 * @return the face of pNode on which pEdge is attached
+	 * @pre storageContains(pEdge)
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 */
+	private Direction attachedSideFromStorage(Edge pEdge, Node pNode)
+	{
+		assert storageContains(pEdge);
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		//Get the connection point of pEdge onto pNode
+		Point connectionPoint = getStoredEdgePath(pEdge).getStartPoint();
+		if (!isOutgoingEdge(pEdge, pNode))
+		{
+			connectionPoint = getStoredEdgePath(pEdge).getEndPoint();
+		}
+		//Iterate over each side of pNode. Return the side which contains connectionPoint
+		Direction[] sides = {Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST};
+		for (Direction side : sides)
+		{
+			if (getNodeFace(getBounds(pNode), side).spanning().contains(connectionPoint))
+			{
+				return side;
+			}
+		}
+		return Direction.NORTH;
+	}
+	
+	/**
+	 * Gets the vertical distance in pixels between the North side of pEndNode and the horizontal middle segment of pEdge.
+	 * @param pEndNode the end node of interest
+	 * @param pEdge the segmented edge of interest
+	 * @param pEdgeDirection the trajectory of pEdge
+	 * @return the absolute value of the distance between the North side of pEndNode and the middle segment of pEdge in pixels.
+	 * @pre pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH	
+	 * @pre pEdge.getEnd() == pEndNode
+	 * @pre EdgePriority.isSegmented(priorityOf(pEdge));
+	 */
+	private int verticalDistanceToNode(Node pEndNode, Edge pEdge, Direction pEdgeDirection) 
+	{
+		assert pEdgeDirection == Direction.NORTH || pEdgeDirection == Direction.SOUTH;	
+		assert EdgePriority.isSegmented(priorityOf(pEdge));
+		assert storageContains(pEdge);
+		return Math.abs(getStoredEdgePath(pEdge).getPointByIndex(1).getY() - pEndNode.position().getY());
+	}
+	
+	/**
+	 * Gets the horizontal distance between the West side of pNode and the vertical middle segment of pEdge.
+	 * @param pEndNode the node of interest. The end node for pEdge. 
+	 * @param pEdge the segmented edge of interest.
+	 * @param pEdgeDirection the trajectory of pEdge
+	 * @return the absolute value of the distance between the West side of pNode and the middle segment of pEdge
+	 * @pre pEdgeDirection == Direction.EAST || PEdgeDirection == Direction.WEST
+	 * @pre EdgePriority.isSegmented(priorityOf(pEdge));
+	 */
+	private int horizontalDistanceToNode(Node pEndNode, Edge pEdge, Direction pEdgeDirection) 
+	{
+		assert pEdgeDirection == Direction.EAST || pEdgeDirection == Direction.WEST;
+		assert EdgePriority.isSegmented(priorityOf(pEdge));
+		assert storageContains(pEdge);
+		return Math.abs(getStoredEdgePath(pEdge).getPointByIndex(1).getX() - pEndNode.position().getX());
+	}
+	
+	/**
+	 * Gets the point from pPoints which is farthest in the direction pEdgeDirection.
+	 * For example, if pDirection is North, it will return the Northern-most point from pPoints.
+	 * @param pPoints the list of edge start points
+	 * @param pDirection the direction used to compare pPoints
+	 * @return the Point which which maximizes pDirection
+	 * @pre pPoints.size() > 0
+	 * @pre pEdgeDirection.iscardinal()
+	 */
+	private Point getClosestPoint(Collection<Point> pPoints, Direction pDirection) 
+	{
+		assert pPoints.size() > 0;
+		assert pDirection!=null && pDirection.isCardinal();
+		if (pDirection == Direction.NORTH)
+		{//Then return the point with the smallest Y-coordinate
+			return pPoints.stream()
+							.min((p1, p2)->Integer.compare(p1.getY(), p2.getY())).orElseGet(null);
+		}
+		else if (pDirection == Direction.SOUTH) 
+		{//Then return the point with the the largest Y-coordinate
+			return pPoints.stream()
+						.max((p1, p2) -> Integer.compare(p1.getY(), p2.getY())).orElseGet(null);
+		}
+		else if (pDirection == Direction.EAST)
+		{//Then return the point with the largest X-coordinate
+			return pPoints.stream()
+				.max((p1, p2)-> Integer.compare(p1.getX() , p2.getX())).orElseGet(null);
+		}
+		else
+		{ //Then return the point with the smallest X-coordinate
+			return pPoints.stream()
+					.min((p1, p2)-> Integer.compare(p1.getX(), p2.getX())).orElseGet(null);
+		}
+	}
+
+	/**
+	 * Checks whether the start labels of pEdge1 and pEdge2 are equal, if they both have start labels. 
+	 * @param pEdge1 an edge of interest
+	 * @param pEdge2 another edge of interest
+	 * @return false if the edges are both ThreeLabelEdge edges with different start labels. True otherwise. 
+	 * @pre pEdge1 != null && pEdge2 != null
+	 */
+	private boolean noConflictingStartLabels(Edge pEdge1, Edge pEdge2)
+	{
+		assert pEdge1 !=null && pEdge2 !=null;
+		if (pEdge1 instanceof ThreeLabelEdge && pEdge2 instanceof ThreeLabelEdge &&
+				priorityOf(pEdge1) == priorityOf(pEdge2))
+		{
+			ThreeLabelEdge labelEdge1 = (ThreeLabelEdge) pEdge1;
+			ThreeLabelEdge labelEdge2 = (ThreeLabelEdge) pEdge2;
+			return labelEdge1.getStartLabel().equals(labelEdge2.getStartLabel());
+		}
+		else
+		{
+			return true;
+		}
+	}
+	
+	/**
+	 * Checks whether the end labels of pEdge1 and pEdge2 are equal, if they both have end labels. 
+	 * @param pEdge1 an edge of interest
+	 * @param pEdge2 another edge of interest
+	 * @return false if the edges are both ThreeLabelEdge edges with different end labels. True otherwise. 
+	 * @pre pEdge1 !=null && pEdge2 !=null
+	 */
+	private boolean noConflictingEndLabels(Edge pEdge1, Edge pEdge2)
+	{
+		assert pEdge1 !=null && pEdge2 !=null;
+		if (pEdge1 instanceof ThreeLabelEdge && pEdge2 instanceof ThreeLabelEdge &&
+				priorityOf(pEdge1) == priorityOf(pEdge2))
+		{
+			ThreeLabelEdge labelEdge1 = (ThreeLabelEdge) pEdge1;
+			ThreeLabelEdge labelEdge2 = (ThreeLabelEdge) pEdge2;
+			return labelEdge1.getEndLabel().equals(labelEdge2.getEndLabel());
+		}
+		else
+		{
+			return true;
+		}
+	}
+	
+	/**
+	 * Returns whether there are any edges connected to pNode in between pEdge1 and pEdge2.
+	 * @param pEdge1 an edge of interest
+	 * @param pEdge2 another edge of interest
+	 * @param pNode the node on which pEdge1 and pEdge2 are attached
+	 * @return true if there are no stored edges on pNode which are attached in between pEdge1 and pEdge2, false otherwise
+	 * @pre pEdge1.getStart() == pNode || pEdge1.getEnd() == pNode
+	 * @pre pEdge2.getStart() == pNode || pEdge2.getEnd() == pNode
+	 * @pre attachedSide(pEdge1, pNode) == attachedSide(pEdge2, pNode)
+	 */
+	private boolean noOtherEdgesBetween(Edge pEdge1, Edge pEdge2, Node pNode)
+	{
+		assert pEdge1.getStart() == pNode || pEdge1.getEnd() == pNode;
+		assert pEdge2.getStart() == pNode || pEdge2.getEnd() == pNode;
+		assert attachedSide(pEdge1, pNode) == attachedSide(pEdge2, pNode);
+		if (pEdge1.equals(pEdge2))
+		{
+			return true;
+		}
+		//Return true if there are no other stored edges connected to the same side of pNode as pEdge1 and pEdge2
+		if(classDiagramViewerFor(pEdge1).storedEdgesConnectedTo(pNode).stream()
+					.filter(edge -> attachedSide(edge, pNode) == attachedSide(pEdge1, pNode))
+					.collect(toList()).isEmpty()) 
+		{
+			return true;
+		}
+		else
+		{	//Compare the center point of pNode to the center points of the other nodes of pEdge1 and pEdge2:
+			return nodesOnSameSideOfCommonNode(getOtherNode(pEdge1, pNode), getOtherNode(pEdge2, pNode), 
+					pNode, attachedSide(pEdge1, pNode));
+		}
+	}
+	
+	/**
+	 * Returns whether the center points of pNode1 and pNode2 are both on the same side relative to the center point of pCommonNode.
+	 * @param pNode1 a node in the diagram
+	 * @param pNode2 another node in the diagram
+	 * @param pCommonNode aNode which has edges which connect to both pNode1 and pNode2
+	 * @param pAttachedSide the side of pCommonNode on which the edges from pNode1 and pNode2 connect
+	 * @return true if the center points of pNode1 and pNode2 are both above, below, to the left, or to the right 
+	 * 	of the center point of pCommonNode. False otherwise.
+	 * @pre pAttachedSide.isCardinal()
+	 */
+	private boolean nodesOnSameSideOfCommonNode(Node pNode1, Node pNode2, Node pCommonNode, Direction pAttachedSide)
+	{
+		assert pAttachedSide.isCardinal();
+		//Compare positions of pNode1 and pNode2 to the position of pCommonNode
+		Point node1Center = getBounds(pNode1).getCenter();
+		Point node2Center = getBounds(pNode2).getCenter();
+		Point commonNodeCenter = getBounds(pCommonNode).getCenter();
+		if (pAttachedSide == Direction.NORTH || pAttachedSide == Direction.SOUTH)//then compare X-coordinates
+		{
+			return node1Center.getX() <= commonNodeCenter.getX() && node2Center.getX() <= commonNodeCenter.getX() ||
+					node1Center.getX() >= commonNodeCenter.getX() && node2Center.getX() >= commonNodeCenter.getX();
+		}
+		else//compare y-coordinates
+		{
+			return node1Center.getY() <= commonNodeCenter.getY() && node2Center.getY() <= commonNodeCenter.getY() ||
+					node1Center.getY() >= commonNodeCenter.getY() && node2Center.getY() >= commonNodeCenter.getY();
+		}
+	}
+	
+	/**
+	 * Gets the connection point for pEdge on the pAttachmentSide of pNode. Checks with the diagram's EdgeStorage to find the
+	 * closest available connection point to the center point (NodeIndex ZERO). 
+	 * @param pNode the node of interest
+	 * @param pEdge the edge of interest
+	 * @return the Point where pEdge connects to pNode
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode	
+	 * @pre pAttachmentSide.isCardinal()
+	 */
+	private Point getConnectionPoint(Node pNode, Edge pEdge, Direction pAttachmentSide)
+	{
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;	
+		assert pAttachmentSide.isCardinal();
+		Line faceOfNode = getNodeFace(getBounds(pNode), pAttachmentSide);
+		//North and South node sides have connection points: -4 ...0... +4
+		//East and West node sides have connection points: -2 ...0... +2
+		int maxIndex = 4; 
+		if (pAttachmentSide == Direction.EAST || pAttachmentSide == Direction.WEST)
+		{
+			maxIndex = 2; 
+		}
+		//Get the index sign (either -1 or +1)
+		int indexSign = getIndexSign(pEdge, pNode, pAttachmentSide);
+		//Get the first available connection point, starting at NodeIndex ZERO and moving outwards 
+		for (int offset = 0; offset <= maxIndex; offset++) 
+		{
+			int ordinal = 4 + (indexSign * offset);
+			NodeIndex index = NodeIndex.values()[ordinal];
+			Point indexPoint = NodeIndex.toPoint(faceOfNode, pAttachmentSide, index);
+			if (classDiagramViewerFor(pEdge).connectionPointAvailableInStorage(indexPoint))
+			{
+				return indexPoint;
+			}
+		}
+		//If no connection point was available, return the point at NodeIndex MINUS_FOUR or PLUS_FOUR	
+		int maxOrdinal = 4 + ( maxIndex * indexSign );
+		return NodeIndex.toPoint(faceOfNode, pAttachmentSide, NodeIndex.values()[maxOrdinal]);
+	}
+	
+	/**
+	 * Returns the node connected to pEdge which is not pNode.
+	 * @param pEdge the edge of interest
+	 * @param pNode a node attached to pEdge
+	 * @return the other node attached to pEdge
+	 * @pre pEdge!=null
+	 * @pre pNode!=null
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 */
+	private Node getOtherNode(Edge pEdge, Node pNode)
+	{
+		assert pEdge!=null;
+		assert pNode!=null;
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		if (pEdge.getStart() == pNode)
+		{
+			return pEdge.getEnd();
+		}
+		else
+		{
+			return pEdge.getStart();
+		}
+	}
+	
+	
+	/**
+	 * Gets the index sign (-1 or 1) describing the attachment of pNode on pEdge.
+	 * 
+	 * Edges which share both their start and end nodes with another edge (shared-node edges) should have the same index sign, regardless
+	 * of whether they are outgoing or incoming on pNode. 
+	 * 
+	 * For all other edges, the index sign can be obtained by 
+	 * comparing the relative positions of pNode and the other Node attached to pEdge. 
+	 * 
+	 * @param pEdge the edge of interest
+	 * @param pNode the node for which we want the index sign
+	 * @param pSideOfNode the cardinal direction describing the side of pNode where pEdge attaches
+	 * @return the index sign (-1 or 1) describing the attachment of pEdge onto pNode.
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 * @pre pSideOfNode.isCardinal()
+	 */
+	private int getIndexSign(Edge pEdge, Node pNode, Direction pSideOfNode)
+	{
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		//Check whether there are any stored edges which are connected to both pEdge.getStart() and pEdge.getEnd()
+		List<Edge> edgesWithSameNodes = classDiagramViewerFor(pEdge).storedEdgesWithSameNodes(pEdge);
+		if (!edgesWithSameNodes.isEmpty()) 
+		{	//For shared-nod edge: index sign on start node should always be same as end node index sign
+			return indexSignOnNode(pEdge, pEdge.getEnd(), pEdge.getStart(), attachedSide(pEdge, pEdge.getEnd()));
+		}
+		else
+		{
+			return indexSignOnNode(pEdge, pNode, getOtherNode(pEdge, pNode), pSideOfNode);
+		}
+	}
+	
+	/**
+	 * Gets the index sign (-1 or 1) describing the attachment of pNode on pEdge.
+	 * Compares the relative positions of pNode and pOtherNode to determine if the index sign should be -1 or +1.
+	 * @param pEdge the edge of interest
+	 * @param pNode the node for which we want to compute the index sign
+	 * @param pOtherNode the node attached to pEdge which is not pNode
+	 * @param pSideOfNode the cardinal direction describing the side of pNode where pEdge could attach
+	 * @return the index sign (-1 or 1) describing the attachment of pEdge onto pNode.
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 * @pre getOtherNode(pEdge, pNode).equals(pOtherNode)
+	 * @pre pSideOfNode.isCardinal()
+	 */
+	private int indexSignOnNode(Edge pEdge, Node pNode, Node pOtherNode, Direction pSideOfNode)
+	{
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		assert getOtherNode(pEdge, pNode).equals(pOtherNode);
+		assert pSideOfNode.isCardinal();
+		if (pSideOfNode == Direction.NORTH || pSideOfNode == Direction.SOUTH) //then compare X-coordinates
+		{
+			if (NodeViewerRegistry.getBounds(pNode).getCenter().getX() <=  NodeViewerRegistry.getBounds(pOtherNode).getCenter().getX())
+			{
+				return 1;
+			}
+			else 
+			{
+				return -1;
+			}	
+		}
+		else //Side of node is East/West, so we need to compare Y-coordinates
+		{
+			if (NodeViewerRegistry.getBounds(pNode).getCenter().getY() <=  NodeViewerRegistry.getBounds(pOtherNode).getCenter().getY())
+			{
+				return 1;
+			}
+			else
+			{
+				return -1;
+			}
+		}
+	}
+	
+	
+	/**
+	 * Gets a line representing the pSideOfNode side of pNode. 
+	 * @param pNode the node of interest
+	 * @param pSideOfNode the desired side of pNode
+	 * @return a line spanning the pSideOfNode side of pNode
+	 * @pre pNodeBounds != null
+	 * @pre pSideOfNode.isCardinal()
+	 */
+	private Line getNodeFace(Rectangle pNodeBounds, Direction pSideOfNode)
+	{
+		assert pNodeBounds !=null && pSideOfNode.isCardinal();
+		Point topLeft = pNodeBounds.getOrigin();
+		Point topRight = new Point(pNodeBounds.getMaxX(), pNodeBounds.getY());
+		Point bottomLeft = new Point(pNodeBounds.getX(), pNodeBounds.getMaxY());
+		Point bottomRight = new Point(pNodeBounds.getMaxX(), pNodeBounds.getMaxY());
+		if (pSideOfNode == Direction.SOUTH)
+		{
+			return new Line(bottomLeft, bottomRight);
+		}
+		else if (pSideOfNode == Direction.NORTH)
+		{
+			return new Line(topLeft, topRight);
+		}
+		else if (pSideOfNode == Direction.WEST)
+		{
+			return new Line(topLeft, bottomLeft);
+		}
+		else 
+		{
+			return new Line(topRight, bottomRight);
+		}
+	}
+	
+	/**
+	 * Returns whether pEdge is an outgoing edge from pNode.
+	 * @param pEdge the edge of interest
+	 * @param pNode the node of interest
+	 * @return true if pEdge is outgoing from pNode, false otherwise
+	 * @pre pNode!=null
+	 * @pre pEdge!=null
+	 */
+	private boolean isOutgoingEdge(Edge pEdge, Node pNode)
+	{
+		assert pEdge!=null && pNode!=null;
+		return pEdge.getStart() == pNode;
+	}
+	
+	/**
+	 * Gets the Direction describing the side of pNode that pEdge should be attached to.
+	 * @param pEdge the edge of interest
+	 * @param pNode the node of interest
+	 * @return the cardinal side of pNode where pEdge should be attached.
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode 
+	 */
+	private Direction attachedSide(Edge pEdge, Node pNode)
+	{
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		Direction startAttachedSide;
+		/* If there is an Edge in storage which is also attached to pEdge.getStart() and pEdge.getEnd()
+		  then the attachment side of pEdge onto pNode must be the same as the attachment side of the 
+		  stored node onto pNode. (These are referred to as "shared-node edges").
+		*/
+		List<Edge> edgesWithSameNodes = classDiagramViewerFor(pEdge).storedEdgesWithSameNodes(pEdge);
+		if (!edgesWithSameNodes.isEmpty())
+		{
+			return attachedSideFromStorage(edgesWithSameNodes.get(0), pNode);
+		}
+		//AggregationEdges prefer to attach on East/West sides, unless nodes are directly above/below each other
+		if (pEdge instanceof AggregationEdge)
+		{
+			startAttachedSide = attachedSidePreferringEastWest(pEdge);	
+		}
+		//Other edges prefer to attach on North/South sides, unless nodes are directly beside each other
+		else
+		{
+			startAttachedSide = attachedSidePreferringNorthSouth(pEdge);
+		}
+		//The attached side of pEdge to its end node is always opposite of the attachment side to its start node
+		if (isOutgoingEdge(pEdge, pNode))
+		{
+			return startAttachedSide;
+		}
+		else
+		{
+			return startAttachedSide.mirrored();
+		}
+	}
+	
+
+	/**
+	 * Gets the cardinal direction describing the side of pEdge's start node on which pEdge should attach.
+	 * pEdge should connect to the East or West sides unless its nodes are directly above or below each other. 
+	 * @param pEdge the edge of interest
+	 * @return the cardinal side of pNode that pEdge should be attached to
+	 * @pre pEdge != null
+	 */
+	private Direction attachedSidePreferringEastWest(Edge pEdge)
+	{
+		assert pEdge != null;
+		Rectangle startNodeBounds = NodeViewerRegistry.getBounds(pEdge.getStart());
+		Rectangle endNodeBounds = NodeViewerRegistry.getBounds(pEdge.getEnd());
+		//if the start node is above or below the end node (+- 20 px) then determine whether it belongs on the N or S side
+		if (startNodeBounds.getMaxX() > endNodeBounds.getX() - (2 * TEN_PIXELS) &&
+				startNodeBounds.getX() < endNodeBounds.getMaxX() + (2 * TEN_PIXELS))
+		{
+			return northSouthSideUnlessTooClose(pEdge);		
+		}
+		else
+		{
+			return eastWestSideUnlessTooClose(pEdge);
+		}
+		
+	}
+	
+	/**
+	 * Gets the side of pEdge's start node that pEdge should attach to.  
+	 * @param pEdge the edge of interest
+	 * @return the North/South side of pEdge's start node which pEdge should attach to, unless pEdge's nodes are directly beside each other.
+	 */
+	private Direction attachedSidePreferringNorthSouth(Edge pEdge)
+	{
+		assert pEdge!= null;
+		Rectangle startNodeBounds = NodeViewerRegistry.getBounds(pEdge.getStart());
+		Rectangle endNodeBounds = NodeViewerRegistry.getBounds(pEdge.getEnd());
+		//if the start node is beside the end node (+- 20 px) then compute whether it belongs on the E or W side
+		if (startNodeBounds.getMaxY() > endNodeBounds.getY() - (2 * TEN_PIXELS) && 
+				startNodeBounds.getY() < endNodeBounds.getMaxY() + (2 * TEN_PIXELS))
+		{
+			return eastWestSideUnlessTooClose(pEdge);
+		}
+		else //compute whether it belongs on the N or S side
+		{
+			return northSouthSideUnlessTooClose(pEdge);
+		}
+	}
+	
+	/**
+	 * Returns the side of pEdge's start node that pEdge should attach to. This side will be either North or South, unless
+	 * pEdge's nodes are closer to each other than they are to pEdge's middle segment. In that case, it returns the East/West attachment side.
+	 * @param pEdge the edge of interest
+	 * @return the attachment side of pEdge 
+	 */
+	private Direction northSouthSideUnlessTooClose(Edge pEdge)
+	{
+		Direction preferredSide = northOrSouthSide(NodeViewerRegistry.getBounds(pEdge.getStart()), 
+				NodeViewerRegistry.getBounds(pEdge.getEnd()));
+		if (nodeIsCloserThanSegment(pEdge, pEdge.getEnd(), preferredSide) || 
+				nodeIsCloserThanSegment(pEdge, pEdge.getStart(), preferredSide.mirrored()))
+		{
+			return eastOrWestSide(NodeViewerRegistry.getBounds(pEdge.getStart()), NodeViewerRegistry.getBounds(pEdge.getEnd()));
+		}
+		else
+		{
+			return preferredSide;
+		}
+	}
+	
+	/**
+	 * Returns whether pEdge should attach on the East or West side of its start node, unless
+	 * pEdge's nodes are too close together, in which case it returns the North/South attachment side.
+	 * @param pEdge the edge of interest
+	 * @return the attachment side of pEdge 
+	 */
+	private Direction eastWestSideUnlessTooClose(Edge pEdge)
+	{
+		Direction preferredSide = eastOrWestSide(NodeViewerRegistry.getBounds(pEdge.getStart()), 
+				NodeViewerRegistry.getBounds(pEdge.getEnd()));
+		if (nodeIsCloserThanSegment(pEdge, pEdge.getEnd(), preferredSide) || 
+				nodeIsCloserThanSegment(pEdge, pEdge.getStart(), preferredSide.mirrored()))
+		{
+			return northOrSouthSide(NodeViewerRegistry.getBounds(pEdge.getStart()), NodeViewerRegistry.getBounds(pEdge.getEnd()));
+		}
+		else
+		{
+			return preferredSide;
+		}
+	}
+	
+	/**
+	 * Compares the relative positions of pBounds and pOtherBounds to determine if an edge connecting
+	 * pBounds and pOtherBounds should connect on the North or South side of pBounds. 
+	 * @param pBounds the rectangle of interest
+	 * @param pOtherBounds another rectangle to compare with
+	 * @return the side of pBounds (either North or South) where an edge connecting pBounds and pOtherBounds should attach.
+	 * @pre pBounds != null && pOtherBounds != null
+	 */
+	private Direction northOrSouthSide(Rectangle pBounds, Rectangle pOtherBounds)
+	{
+		assert pBounds != null && pOtherBounds != null;
+		if (pOtherBounds.getCenter().getY() < pBounds.getCenter().getY())
+		{
+			return Direction.NORTH;
+		}
+		else
+		{
+			return Direction.SOUTH;
+		}
+	}
+	
+	/**
+	 * Compares the relative positions of pBounds and pOtherBounds to determine if an edge connecting
+	 * pBounds and pOtherBounds should connect on the East or West side of pBounds. 
+	 * @param pBounds the rectangle of interest
+	 * @param pOtherBounds another rectangle to compare with
+	 * @return the side of pBounds (either East or West) where an edge connecting pBounds and pOtherBounds should attach.
+	 * @pre pBounds !=null && pOtherBounds !=null
+	 */
+	private Direction eastOrWestSide(Rectangle pBounds, Rectangle pOtherBounds)
+	{
+		assert pBounds !=null && pOtherBounds !=null;
+		if (pOtherBounds.getCenter().getX() < pBounds.getCenter().getX() )
+		{
+			return Direction.WEST;
+		}
+		else
+		{
+			return Direction.EAST;
+					
+		}
+	}
+	
+	/**
+	 * Returns whether the other node attached to pEdge is closer to pNode than pEdge's middle segment. 
+	 * @param pEdge the edge of interest
+	 * @param pNode a node attached to pEdge 
+	 * @param pAttachedSide the cardinal direction describing the side of pNode where pEdge is attached
+	 * @return true if pEdge's other node is closer to pNode than pEdge's middle segment is, false otherwise.
+	 * @pre pEdge.getStart() == pNode || pEdge.getEnd() == pNode
+	 * @pre pAttachedSide.isCardinal()
+	 */
+	private boolean nodeIsCloserThanSegment(Edge pEdge, Node pNode, Direction pAttachedSide)
+	{
+		assert pEdge.getStart() == pNode || pEdge.getEnd() == pNode;
+		assert pAttachedSide.isCardinal();
+		Rectangle otherNodeBounds = NodeViewerRegistry.getBounds(getOtherNode(pEdge, pNode));
+		if (pAttachedSide == Direction.NORTH)
+		{ //Consider the middle segments of edges attached to pNode
+			return !storedConflictingEdges(pAttachedSide.mirrored(), pNode, pEdge).stream()
+					.filter(edge -> otherNodeBounds.getY() < getStoredEdgePath(edge).getPointByIndex(1).getY() - TEN_PIXELS)
+					.collect(toList())
+					.isEmpty();
+		}
+		else if (pAttachedSide == Direction.SOUTH)
+		{//Consider the middle segments of edges attached to pNode
+			return !storedConflictingEdges(pAttachedSide.mirrored(), pNode, pEdge).stream()
+					.filter(edge -> otherNodeBounds.getMaxY() > getStoredEdgePath(edge).getPointByIndex(1).getY() + TEN_PIXELS)
+					.collect(toList())
+					.isEmpty();
+		}
+		else if (pAttachedSide == Direction.EAST)
+		{//Consider the middle segments of edges attached to pNode
+			return !storedConflictingEdges(pAttachedSide.mirrored(), pNode, pEdge).stream()
+					.filter(edge -> otherNodeBounds.getMaxX() > getStoredEdgePath(edge).getPointByIndex(1).getX() - TEN_PIXELS)
+					.collect(toList())
+					.isEmpty();
+		}
+		else //Direction is WEST
+		{//Consider the middle segments of edges attached to pNode
+			return !storedConflictingEdges(pAttachedSide.mirrored(), pNode, pEdge).stream()
+					.filter(edge -> otherNodeBounds.getX() < getStoredEdgePath(edge).getPointByIndex(1).getX() + TEN_PIXELS)
+					.collect(toList())
+					.isEmpty();
+		}
+	}
+	
+	/**
+	 * Returns the ClassDiagramViewer associated with pEdge's Diagram.
+	 * @param pEdge the Edge of interest
+	 * @return the ClassDiagramViewer for the Diagram which pEdge is part of.
+	 * @pre DiagramType.viewerFor(pEdge.getDiagram()) instanceof ClassDiagramViewer
+	 */
+	private ClassDiagramViewer classDiagramViewerFor(Edge pEdge)
+	{
+		assert DiagramType.viewerFor(pEdge.getDiagram()) instanceof ClassDiagramViewer;
+		return (ClassDiagramViewer) DiagramType.viewerFor(pEdge.getDiagram());
+	}
+
+	/**
+	 * Gets the EdgePath of pEdge from storage.
+	 * @param pEdge the edge of interest
+	 * @return the stored EdgePAth of pEdge
+	 * @pre the diagram's EdgeStorage contains pEdge
+	 */
+	private EdgePath getStoredEdgePath(Edge pEdge)
+	{
+		ClassDiagramViewer classDiagramViewer = (ClassDiagramViewer) DiagramType.viewerFor(pEdge.getDiagram());
+		assert classDiagramViewer.storageContains(pEdge);
+		return classDiagramViewer.storedEdgePath(pEdge);
+	}
+
+	/**
+	 * Returns whether pEdge is present in the EdgeStorage associated with its Diagram.
+	 * @param pEdge the Edge of interest
+	 * @return true if EdgeStorage contains pEdge, false otherwise.
+	 */
+	private boolean storageContains(Edge pEdge)
+	{
+		ClassDiagramViewer classDiagramViewer = (ClassDiagramViewer) DiagramType.viewerFor(pEdge.getDiagram());
+		return classDiagramViewer.storageContains(pEdge);
+	}
+}

--- a/src/ca/mcgill/cs/jetuml/viewers/NodeCorner.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/NodeCorner.java
@@ -1,0 +1,126 @@
+package ca.mcgill.cs.jetuml.viewers;
+
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.edges.NodeIndex;
+import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
+
+/**
+ * Represents the 4 corners of a node. Used to plan the placement of self-edges.
+ *
+ */
+public enum NodeCorner 
+{
+	TOP_RIGHT, TOP_LEFT, BOTTOM_LEFT, BOTTOM_RIGHT;
+	
+	private static final int TWENTY_PIXELS = 20;
+	
+	/**
+	 * Gets the horizontal (North or South) NodeIndex associated with pCorner.
+	 * @param pCorner the node corner
+	 * @return +3 if the corner is a right corner, -3 otherwise
+	 */
+	public static NodeIndex getHorizontalIndex(NodeCorner pCorner)
+	{
+		if (pCorner == BOTTOM_RIGHT || pCorner == TOP_RIGHT)
+		{
+			return NodeIndex.PLUS_THREE;
+		}
+		else
+		{
+			return NodeIndex.MINUS_THREE;
+		}
+	}
+	
+	/**
+	 * Gets the vertical (East or West) NodeIndex associated with pCorner.
+	 * @param pCorner the node corner
+	 * @return +1 if the corner is a top corner, -1 otherwise.
+	 */
+	public static NodeIndex getVerticalIndex(NodeCorner pCorner)
+	{
+		if (pCorner == TOP_LEFT || pCorner == TOP_RIGHT)
+		{
+			return NodeIndex.MINUS_ONE;
+		}
+		else
+		{
+			return NodeIndex.PLUS_ONE;
+		}
+	}
+	
+	/**
+	 * Gets the Direction (either North or South) describing pCorner's horizontal position on a node.
+	 * @param pCorner the node corner of interest
+	 * @return NORTH if the corner is a top corner, SOUTH if the corner is a bottom corner.
+	 * @pre pCorner != null;
+	 */
+	public static Direction horizontalSide(NodeCorner pCorner)
+	{
+		assert pCorner != null;
+		if (pCorner == TOP_RIGHT || pCorner == TOP_LEFT)
+		{
+			return Direction.NORTH;
+		}
+		else
+		{
+			return Direction.SOUTH;
+		}
+	}
+	
+	
+	/**
+	 * Gets the Direction (either EAST or WEST) describing pCorner's vertical position on a node.
+	 * @param pCorner the node corner of interest
+	 * @return EAST if the corner is a right corner, WEST if the corner is a left corner.
+	 */
+	public static Direction verticalSide(NodeCorner pCorner)
+	{
+		assert pCorner != null;
+		if (pCorner == TOP_RIGHT || pCorner == BOTTOM_RIGHT)
+		{
+			return Direction.EAST;
+		}
+		else
+		{
+			return Direction.WEST;
+		}
+	}
+	
+	/**
+	 * Returns an array of [startPoint, endPoint] where a self-edge attached to the pCorner of pNode would connect.
+	 * @param pCorner the NodeCorner of interest
+	 * @param pNode the node of interest 
+	 * @return an array containing the start point and end point for a self edge attached to the pCorner corner of pNode.
+	 */
+	public static Point[] toPoints(NodeCorner pCorner, Node pNode)
+	{
+		Rectangle nodeBounds = NodeViewerRegistry.getBounds(pNode);
+		Point startPoint;
+		Point endPoint;		
+		if (pCorner == TOP_RIGHT)
+		{
+			startPoint = new Point(nodeBounds.getMaxX() - TWENTY_PIXELS, nodeBounds.getY());
+			endPoint = new Point(nodeBounds.getMaxX(), nodeBounds.getY() + TWENTY_PIXELS);
+		}
+		else if (pCorner == TOP_LEFT)
+		{
+			startPoint = new Point(nodeBounds.getX() + TWENTY_PIXELS, nodeBounds.getY());
+			endPoint = new Point(nodeBounds.getX(), nodeBounds.getY() + TWENTY_PIXELS);
+		}
+		else if (pCorner == BOTTOM_LEFT)
+		{
+			startPoint = new Point(nodeBounds.getX() + TWENTY_PIXELS, nodeBounds.getMaxY());
+			endPoint = new Point(nodeBounds.getX(), nodeBounds.getMaxY() - TWENTY_PIXELS);
+		}
+		else //BOTTOM_RIGHT
+		{
+			startPoint = new Point(nodeBounds.getMaxX() - TWENTY_PIXELS, nodeBounds.getMaxY());
+			endPoint = new Point(nodeBounds.getMaxX(), nodeBounds.getMaxY() - TWENTY_PIXELS);
+		}
+		return new Point[] {startPoint, endPoint};
+	}
+}
+

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/EdgeStorage.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/EdgeStorage.java
@@ -1,0 +1,131 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Point;
+
+/**
+ * Stores the EdgePaths of Edges for class diagrams.
+ */
+public class EdgeStorage
+{
+	private Map<Edge, EdgePath> aEdgePaths = new IdentityHashMap<>();
+ 	
+ 	/**
+ 	 * Adds pEdge and pEdgePath into storage.
+ 	 * If pEdge is already in storage, then its EdgePath is updated to pEdgePath.
+ 	 * @param pEdge the edge to store
+ 	 * @pre pEdge!=null
+ 	 * @pre pEdgePath!=null
+ 	 */
+ 	public void store(Edge pEdge, EdgePath pEdgePath)
+ 	{
+ 		assert pEdge!=null && pEdgePath!=null;
+ 		aEdgePaths.put(pEdge, pEdgePath);
+ 	}
+ 
+ 	
+ 	/**
+ 	 * Returns whether storage is empty.  
+ 	 * @return true if aEdgePaths is empty, false otherwise.
+ 	 */
+ 	public boolean isEmpty()
+ 	{
+ 		return aEdgePaths.isEmpty();
+ 	}
+ 	
+ 	/**
+ 	 * Returns pEdge's EdgePath from storage.
+ 	 * @param pEdge the stored edge of interest
+ 	 * @return the EdgePath for pEdge from storage 
+ 	 * @pre pEdge!=null
+ 	 * @pre this.contains(pEdge)
+ 	 */
+ 	public EdgePath getEdgePath(Edge pEdge)
+ 	{
+ 		assert pEdge!=null;
+ 		assert this.contains(pEdge);
+ 		return aEdgePaths.get(pEdge);
+	
+ 	}
+ 	
+ 	/**
+ 	 * Returns whether pEdge is in storage.
+ 	 * @param pEdge the edge of interest
+ 	 * @return true if pEdge is in storage, false otherwise
+ 	 * @pre pEdge!=null
+ 	 */
+ 	public boolean contains(Edge pEdge)
+ 	{
+ 		assert pEdge!=null;
+ 		return aEdgePaths.containsKey(pEdge);
+ 	}
+
+ 	/**
+ 	 * Returns a list of edges in storage which are connected to pNode.
+	 * @param pNode The node of interest
+	 * @return All the edges connected to pNode
+	 * @pre pNode != null
+	 */
+	public List<Edge> edgesConnectedTo(Node pNode)
+	{
+		assert pNode != null;
+		List<Edge> result = new ArrayList<>();
+		for( Edge edge : aEdgePaths.keySet() )
+		{
+			if( edge.getStart() == pNode || edge.getEnd() == pNode )
+			{
+				result.add(edge);
+			}
+		}
+		return result;
+	}
+	
+	/**
+	 * Returns whether pConnectionPoint is available.
+	 * @param pConnectionPoint a Point in the diagram
+	 * @return false if pPoint is a start or end connection point for an edge in storage, true otherwise
+	 * @pre pConnectionPoint !=null;
+	 */
+	public boolean connectionPointIsAvailable(Point pConnectionPoint)
+	{
+		assert pConnectionPoint !=null;
+		for( EdgePath path : aEdgePaths.values() )
+		{
+			if (path.getStartPoint().equals(pConnectionPoint) || path.getEndPoint().equals(pConnectionPoint))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * Returns a list of edges which share the same two attached nodes as pEdge, reffered to as "shared-node edges".
+	 * Based on diagram constraints, this list will typically either be empty or contain a maximum of 1 edge. 
+	 * @param pEdge the edge of interest
+	 * @return a list of edges from storage which are also attached to pEdge.getStart() and pEdge.getEnd(). 	 
+	 */
+	public List<Edge> getEdgesWithSameNodes(Edge pEdge)
+	{
+		return aEdgePaths.keySet().stream()
+				.filter(edge -> edge.getStart() == pEdge.getStart() || edge.getStart() == pEdge.getEnd())
+				.filter(edge -> edge.getEnd() == pEdge.getStart() || edge.getEnd() == pEdge.getEnd())
+				.filter(edge -> !edge.equals(pEdge))
+				.collect(Collectors.toList());
+	}
+	
+	/**
+	 * Clears edge storage.
+	 */
+	public void clearStorage()
+	{
+		aEdgePaths.clear();
+	}
+}

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/NodeIndex.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/NodeIndex.java
@@ -1,0 +1,73 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.Line;
+import ca.mcgill.cs.jetuml.geom.Point;
+
+/**
+ * Represents indexed positions on the faces of nodes where edges can attach.
+ * North-facing and South-facing sides of nodes have indices in range -4 to +4.
+ * East and West-facing sides of nodes have indices in range -2 to +2.
+ */
+public enum NodeIndex 
+{
+	MINUS_FOUR, MINUS_THREE, MINUS_TWO, MINUS_ONE, ZERO,
+	PLUS_ONE, PLUS_TWO, PLUS_THREE, PLUS_FOUR;
+	
+	private static final int NUM_SPACES_NS = 10;
+	private static final int NUM_SPACES_EW = 6;
+	
+	/**
+	 * Returns a point on pNodeFace at the pNodeIndex position.
+	 * @param pNodeFace a Line representing the side of pNode where the point is needed.
+	 * @param pAttatchmentSide the side of the node of interest
+	 * @param pNodeIndex the indexed position on pNodeFace
+	 * @return a point on pNodeFace at the pNodeIndex position
+	 * @pre pNodeFace != null
+	 * @pre pAttachmentSide.isCardinal()
+	 * @pre pNodeIndex != null
+	 */
+	public static Point toPoint(Line pNodeFace, Direction pAttachmentSide, NodeIndex pNodeIndex)
+	{
+		//determine the offset from the center point. 
+		float spacing = spaceBetweenConnectionPoints(pNodeFace, pAttachmentSide);
+		int offset = (int) ((pNodeIndex.ordinal() - 4) * spacing);
+		
+		//Determine center point and add the offset to the center point
+		Point center;
+		if (pAttachmentSide == Direction.NORTH || pAttachmentSide == Direction.SOUTH)
+		{
+			center = new Point(((pNodeFace.getX2() - pNodeFace.getX1())/2) + pNodeFace.getX1(), pNodeFace.getY1());
+			return new Point(center.getX() + offset, center.getY());
+		}
+		else 
+		{
+			center = new Point(pNodeFace.getX1(), ((pNodeFace.getY2() - pNodeFace.getY1())/2) + pNodeFace.getY1());
+			return new Point(center.getX(), center.getY() + offset);
+		}
+	}
+	
+	/**
+	 * Determines the number of pixels in between edge connection points on pNode. 
+	 * This allows the space between NodeIndex connection points
+	 *  to increase proportionally with the width or height of the node. 
+	 * @param pNodeFace a line representing the pAttachmentSide of a node
+	 * @param pAttachmentSide a cardinal direction describing a side of a node. 
+	 * @return the spacing in between connection points on pNodeFace. 
+	 * @pre pNodeFace != null
+	 * @pre pAttachmentSide.isCardinal()
+	 */
+	private static float spaceBetweenConnectionPoints(Line pNodeFace, Direction pAttachmentSide)
+	{
+		assert pNodeFace != null;
+		assert pAttachmentSide.isCardinal();
+		if (pAttachmentSide == Direction.NORTH || pAttachmentSide == Direction.SOUTH)
+		{
+			return (float) (Math.abs((pNodeFace.getX2() - pNodeFace.getX1()) / NUM_SPACES_NS));
+		}
+		else
+		{
+			return (float) (Math.abs((pNodeFace.getY2() - pNodeFace.getY1()) / NUM_SPACES_EW));
+		}
+	}
+}

--- a/src/ca/mcgill/cs/jetuml/viewers/edges/StoredEdgeViewer.java
+++ b/src/ca/mcgill/cs/jetuml/viewers/edges/StoredEdgeViewer.java
@@ -1,0 +1,491 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge.Type;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge.Directionality;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.SingleLabelEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.ThreeLabelEdge;
+import ca.mcgill.cs.jetuml.geom.Dimension;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Line;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.ArrowHead;
+import ca.mcgill.cs.jetuml.viewers.ClassDiagramViewer;
+import ca.mcgill.cs.jetuml.viewers.EdgePriority;
+import ca.mcgill.cs.jetuml.viewers.LineStyle;
+import ca.mcgill.cs.jetuml.viewers.StringViewer;
+import ca.mcgill.cs.jetuml.viewers.ToolGraphics;
+import ca.mcgill.cs.jetuml.viewers.StringViewer.Alignment;
+import javafx.geometry.Bounds;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
+import javafx.scene.shape.Shape;
+import static ca.mcgill.cs.jetuml.viewers.EdgePriority.priorityOf;
+
+/**
+ * Renders the path of stored class diagram edges using EdgeStorage.
+ */
+public class StoredEdgeViewer extends AbstractEdgeViewer
+{
+	private static final StringViewer TOP_CENTERED_STRING_VIEWER = StringViewer.get(Alignment.TOP_CENTER);
+	private static final StringViewer BOTTOM_CENTERED_STRING_VIEWER = StringViewer.get(Alignment.BOTTOM_CENTER);
+	private static final StringViewer LEFT_JUSTIFIED_STRING_VIEWER = StringViewer.get(Alignment.TOP_LEFT);
+	private static final int singleCharWidth = LEFT_JUSTIFIED_STRING_VIEWER.getDimension(" ").width();
+	private static final int singleCharHeight = LEFT_JUSTIFIED_STRING_VIEWER.getDimension(" ").height();
+	private static final int MAX_LENGTH_FOR_NORMAL_FONT = 15;
+	private static final int DEGREES_180 = 180;
+	protected static final int BUTTON_SIZE = 25;
+	protected static final int OFFSET = 3;
+	protected static final int MAX_DISTANCE = 3;
+
+	
+	/**
+	 * Gets the line style for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the LineStyle of pEdge
+	 * @pre pEdge !=null
+	 */
+	private static LineStyle getLineStyle(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if(priorityOf(pEdge) == EdgePriority.IMPLEMENTATION || priorityOf(pEdge) == EdgePriority.DEPENDENCY)
+		{
+			return LineStyle.DOTTED;
+		}
+		else
+		{
+			return LineStyle.SOLID;
+		}
+	}
+	
+	/**
+	 * Gets the start arrow for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the start arrow for pEdge
+	 * @pre pEdge !=null
+	 */
+	private static ArrowHead getArrowStart(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if (pEdge instanceof AggregationEdge)
+		{
+			AggregationEdge edge = (AggregationEdge) pEdge;
+			if (edge.getType() == Type.Composition)
+			{
+				return ArrowHead.BLACK_DIAMOND;
+			}
+			else
+			{
+				return ArrowHead.DIAMOND;
+			}
+		}
+		else if (pEdge instanceof AssociationEdge)
+		{
+			if (((AssociationEdge) pEdge).getDirectionality() == Directionality.Bidirectional)
+			{
+				return ArrowHead.V;
+			}
+		}
+		else if (pEdge instanceof DependencyEdge)
+		{
+			DependencyEdge edge = (DependencyEdge) pEdge;
+			if (edge.getDirectionality() == DependencyEdge.Directionality.Bidirectional)
+			{
+				return ArrowHead.V;
+			}
+		}
+		return ArrowHead.NONE;
+	}
+	
+	/**
+	 * Gets the end arrow for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the end arrow for pEdge
+	 * @pre pEdge !=null
+	 */
+	private static ArrowHead getArrowEnd(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if (pEdge instanceof GeneralizationEdge)
+		{
+			return ArrowHead.TRIANGLE;
+		}
+		else if( pEdge instanceof AggregationEdge)
+		{
+			return ArrowHead.NONE;
+		}
+		else if (pEdge instanceof DependencyEdge)
+		{
+			return ArrowHead.V;
+		}
+		else if (pEdge instanceof AssociationEdge)
+		{
+			AssociationEdge edge = (AssociationEdge) pEdge;
+			if (edge.getDirectionality() == AssociationEdge.Directionality.Unidirectional || 
+					edge.getDirectionality() == AssociationEdge.Directionality.Bidirectional)
+			{
+				return ArrowHead.V;
+			}	
+		}
+		return ArrowHead.NONE;
+		
+	}
+	
+
+	
+
+	/**
+	 * Uses the stored EdgePath of pEdge to create Path representation of its trajectory. 
+	 * @param pEdge the edge of interest
+	 * @return a Path representing the path of pEdge
+	 * @pre pEdge!=null;
+	 */
+	private Path getSegmentPath(Edge pEdge) 
+	{
+		assert pEdge != null;
+		assert pEdge.getDiagram().getType() == DiagramType.CLASS;
+		Path shape = new Path();
+		EdgePath path = getStoredEdgePath(pEdge);
+		shape.getElements().add(new MoveTo(path.getStartPoint().getX(), path.getStartPoint().getY()));
+		for (int i = 1; i < path.size(); i++)
+		{
+			Point point = path.getPointByIndex(i);
+			shape.getElements().add(new LineTo(point.getX(), point.getY()));
+		}
+		return shape;
+	}
+	
+
+	/**
+	 * Returns whether an edge is segmented and is a step up. 
+	 * @param pEdge the edge of interest
+	 * @return true if edge is a step up, false otherwise.
+	 */
+	private boolean isStepUp(Edge pEdge) 
+	{
+		Point point1 = getStoredEdgePath(pEdge).getStartPoint();
+		Point point2 = getStoredEdgePath(pEdge).getEndPoint();
+		return point1.getX() < point2.getX() && point1.getY() > point2.getY() || 
+				point1.getX() > point2.getX() && point1.getY() < point2.getY();
+	}
+	
+
+	/**
+	 * Draws a string.
+	 * @param pGraphics the graphics context
+	 * @param pEndPoint1 an endpoint of the segment along which to draw the string
+	 * @param pEndPoint2 the other endpoint of the segment along which to draw the string
+	 * @param pString the string to draw 
+	 * @param pCenter true if the string should be centered along the segment
+	 */
+	private void drawString(GraphicsContext pGraphics, Point pEndPoint1, Point pEndPoint2, 
+			ArrowHead pArrowHead, String pString, boolean pCenter, boolean pIsStepUp)
+	{
+		if (pString == null || pString.length() == 0)
+		{
+			return;
+		}
+		String label = wrapLabel(pString, pEndPoint1, pEndPoint2);
+		Rectangle bounds = getStringBounds(pEndPoint1, pEndPoint2, pArrowHead, label, pCenter, pIsStepUp);
+		if(pCenter) 
+		{
+			if ( pEndPoint2.getY() >= pEndPoint1.getY() )
+			{
+				TOP_CENTERED_STRING_VIEWER.draw(label, pGraphics, bounds);
+			}
+			else
+			{
+				BOTTOM_CENTERED_STRING_VIEWER.draw(label, pGraphics, bounds);
+			}
+		}
+		else
+		{
+			LEFT_JUSTIFIED_STRING_VIEWER.draw(label, pGraphics, bounds);
+		}
+	}
+	
+	
+	private String wrapLabel(String pString, Point pEndPoint1, Point pEndPoint2) 
+	{
+		int distanceInX = (int)Math.abs(pEndPoint1.getX() - pEndPoint2.getX());
+		int distanceInY = (int)Math.abs(pEndPoint1.getY() - pEndPoint2.getY());
+		int lineLength = MAX_LENGTH_FOR_NORMAL_FONT;
+		double distanceInXPerChar = distanceInX / singleCharWidth;
+		double distanceInYPerChar = distanceInY / singleCharHeight;
+		if (distanceInX > 0)
+		{
+			double angleInDegrees = Math.toDegrees(Math.atan(distanceInYPerChar/distanceInXPerChar));
+			lineLength = Math.max(MAX_LENGTH_FOR_NORMAL_FONT, (int)((distanceInX / 4) * (1 - angleInDegrees / DEGREES_180)));
+		}
+		return LEFT_JUSTIFIED_STRING_VIEWER.wrapString(pString, lineLength);
+		
+	}
+	
+	/**
+	 * Computes the extent of a string that is drawn along a line segment.
+	 * @param p an endpoint of the segment along which to draw the string
+	 * @param q the other endpoint of the segment along which to draw the string
+	 * @param s the string to draw
+	 * @param center true if the string should be centered along the segment
+	 * @return the rectangle enclosing the string
+	*/
+	private static Rectangle getStringBounds(Point pEndPoint1, Point pEndPoint2, 
+			ArrowHead pArrow, String pString, boolean pCenter, boolean pIsStepUp)
+	{
+		if (pString == null || pString.isEmpty())
+		{
+			return new Rectangle((int)Math.round(pEndPoint2.getX()), 
+					(int)Math.round(pEndPoint2.getY()), 0, 0);
+		}
+		Dimension textDimensions = TOP_CENTERED_STRING_VIEWER.getDimension(pString);
+		Rectangle stringDimensions = new Rectangle(0, 0, textDimensions.width(), textDimensions.height());
+		Point a = getAttachmentPoint(pEndPoint1, pEndPoint2, pArrow, stringDimensions, pCenter, pIsStepUp);
+		return new Rectangle((int)Math.round(a.getX()), (int)Math.round(a.getY()),
+				Math.round(stringDimensions.getWidth()), Math.round(stringDimensions.getHeight()));
+	}
+
+	/**
+	 * Computes the attachment point for drawing a string.
+	 * @param pEndPoint1 an endpoint of the segment along which to draw the string
+	 * @param pEndPoint2 the other endpoint of the segment along which to draw the string
+	 * @param b the bounds of the string to draw
+	 * @param pCenter true if the string should be centered along the segment
+	 * @return the point at which to draw the string
+	 */
+	private static Point getAttachmentPoint(Point pEndPoint1, Point pEndPoint2, 
+			ArrowHead pArrow, Rectangle pDimension, boolean pCenter, boolean pIsStepUp)
+	{    
+		final int gap = 3;
+		double xoff = gap;
+		double yoff = -gap - pDimension.getHeight();
+		Point attach = pEndPoint2;
+		if (pCenter)
+		{
+			if (pEndPoint1.getX() > pEndPoint2.getX()) 
+			{ 
+				return getAttachmentPoint(pEndPoint2, pEndPoint1, pArrow, pDimension, pCenter, pIsStepUp); 
+			}
+			attach = new Point((pEndPoint1.getX() + pEndPoint2.getX()) / 2, 
+					(pEndPoint1.getY() + pEndPoint2.getY()) / 2);
+			if (pEndPoint1.getX() == pEndPoint2.getX() && pIsStepUp)
+			{
+				yoff = gap;
+			}
+			else if (pEndPoint1.getX() == pEndPoint2.getX() && !pIsStepUp)
+			{
+				yoff =  -gap-pDimension.getHeight();
+			}
+			else if (pEndPoint1.getY() == pEndPoint2.getY())
+			{
+				if (pDimension.getWidth() > Math.abs(pEndPoint1.getX() - pEndPoint2.getX()))
+				{
+					attach = new Point(pEndPoint2.getX() + (pDimension.getWidth() / 2) + gap, 
+							(pEndPoint1.getY() + pEndPoint2.getY()) / 2);
+				}
+				xoff = -pDimension.getWidth() / 2;
+			}
+		}
+		else 
+		{
+			if(pEndPoint1.getX() < pEndPoint2.getX())
+			{
+				xoff = -gap - pDimension.getWidth();
+			}
+			if(pEndPoint1.getY() > pEndPoint2.getY())
+			{
+				yoff = gap;
+			}
+			if(pArrow != null && pArrow != ArrowHead.NONE)
+			{
+				Bounds arrowBounds = pArrow.view().getPath(pEndPoint1, pEndPoint2).getBoundsInLocal();
+				if(pEndPoint1.getY() == pEndPoint2.getY())
+				{
+					yoff -= arrowBounds.getHeight() / 2;
+				}
+				else if(pEndPoint1.getX() == pEndPoint2.getX())
+				{
+					xoff += arrowBounds.getWidth() / 2;
+				}
+			}
+		}
+		return new Point((int) (attach.getX() + xoff), (int) (attach.getY() + yoff));
+	}
+	
+	/**
+	 * Gets the start label for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the string start label for pEdge
+	 * @pre pEdge != null
+	 */
+	private String getStartLabel(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if (pEdge instanceof ThreeLabelEdge)
+		{
+			ThreeLabelEdge threeLabelEdge = (ThreeLabelEdge) pEdge;
+			return threeLabelEdge.getStartLabel();
+		}
+		else
+		{
+			return "";
+		}
+	}
+	
+	/**
+	 * Gets the middle label for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the String middle label for pEdge
+	 * @pre pEdge != null
+	 */
+	private String getMiddleLabel(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if (pEdge instanceof ThreeLabelEdge)
+		{
+			ThreeLabelEdge threeLabelEdge = (ThreeLabelEdge) pEdge;
+			return threeLabelEdge.getMiddleLabel();
+		}
+		else if (pEdge instanceof SingleLabelEdge)
+		{
+			SingleLabelEdge singleLabelEdge = (SingleLabelEdge) pEdge;
+			return singleLabelEdge.getMiddleLabel();
+		}
+		else
+		{
+			return "";
+		}
+	}
+	
+	/**
+	 * Gets the end label for pEdge.
+	 * @param pEdge the edge of interest
+	 * @return the String end label for pEdge
+	 * @pre pEdge != null
+	 */
+	private String getEndLabel(Edge pEdge)
+	{
+		assert pEdge !=null;
+		if (pEdge instanceof ThreeLabelEdge)
+		{
+			ThreeLabelEdge threeLabelEdge = (ThreeLabelEdge) pEdge;
+			return threeLabelEdge.getEndLabel();
+		}
+		else
+		{
+			return "";
+		}
+	}
+
+	@Override
+	public Rectangle getBounds(Edge pEdge) 
+	{
+		EdgePath path = getStoredEdgePath(pEdge);
+		Rectangle bounds = super.getBounds(pEdge);
+		bounds = bounds.add(getStringBounds(path.getPointByIndex(1), path.getStartPoint(), 
+				getArrowStart(pEdge), getStartLabel(pEdge), false, isStepUp(pEdge)));
+		bounds = bounds.add(getStringBounds(path.getPointByIndex(path.size() / 2 - 1), 
+				path.getPointByIndex(path.size() / 2), null, getMiddleLabel(pEdge), true, isStepUp(pEdge)));
+		bounds = bounds.add(getStringBounds(path.getPointByIndex(path.size() - 2), path.getEndPoint(), 
+				getArrowEnd(pEdge), getEndLabel(pEdge), false, isStepUp(pEdge)));
+		return bounds;
+	}
+
+	@Override
+	protected Shape getShape(Edge pEdge) 
+	{
+		assert pEdge != null;
+		return getSegmentPath(pEdge);
+	}
+
+	@Override
+	public void draw(Edge pEdge, GraphicsContext pGraphics) 
+	{
+		assert pEdge !=null && pGraphics != null;
+		EdgePath path = getStoredEdgePath(pEdge);
+		ToolGraphics.strokeSharpPath(pGraphics, getSegmentPath(pEdge), getLineStyle(pEdge));
+		getArrowStart(pEdge).view().draw(pGraphics, path.getPointByIndex(1), path.getStartPoint());
+		getArrowEnd(pEdge).view().draw(pGraphics, path.getPointByIndex(path.size()-2), path.getEndPoint());
+		drawString(pGraphics, path.getPointByIndex(1), path.getStartPoint(), getArrowStart(pEdge), getStartLabel(pEdge), 
+			false, isStepUp(pEdge));
+		drawString(pGraphics, path.getPointByIndex(path.size() / 2 - 1) , path.getPointByIndex(path.size() / 2), null, 
+			getMiddleLabel(pEdge), true, isStepUp(pEdge));
+		drawString(pGraphics, path.getPointByIndex(path.size()-2), path.getPointByIndex(path.size()-1), 
+			getArrowEnd(pEdge), getEndLabel(pEdge), false, isStepUp(pEdge));
+	}
+
+	@Override
+	public Canvas createIcon(Edge pEdge) 
+	{
+		Canvas canvas = new Canvas(BUTTON_SIZE, BUTTON_SIZE);
+		Path path = new Path();
+		path.getElements().addAll(new MoveTo(OFFSET, OFFSET), new LineTo(BUTTON_SIZE-OFFSET, BUTTON_SIZE-OFFSET));
+		ToolGraphics.strokeSharpPath(canvas.getGraphicsContext2D(), path, getLineStyle(pEdge));
+		getArrowEnd(pEdge).view().draw(canvas.getGraphicsContext2D(), 
+				new Point(OFFSET, OFFSET), new Point(BUTTON_SIZE-OFFSET, BUTTON_SIZE - OFFSET));
+		getArrowStart(pEdge).view().draw(canvas.getGraphicsContext2D(), 
+				new Point(BUTTON_SIZE-OFFSET, BUTTON_SIZE - OFFSET), new Point(OFFSET, OFFSET));
+		return canvas;
+	}
+
+	@Override
+	public void drawSelectionHandles(Edge pEdge, GraphicsContext pGraphics) 
+	{
+		EdgePath path = getStoredEdgePath(pEdge);
+		if (path != null) 
+		{
+			ToolGraphics.drawHandles(pGraphics, new Line(path.getStartPoint(), path.getEndPoint()));
+		}
+	}
+
+	@Override
+	public boolean contains(Edge pEdge, Point pPoint) 
+	{
+		// Purposefully does not include the arrow head and labels, which create large bounds.
+		EdgePath path = getStoredEdgePath(pEdge);
+		if (path == null)
+		{
+			return false;
+		}
+		else
+		{
+			if(pPoint.distance(path.getStartPoint()) <= MAX_DISTANCE || pPoint.distance(path.getEndPoint()) <= MAX_DISTANCE)
+			{
+				return true;
+			}
+			Shape fatPath = getShape(pEdge);
+			fatPath.setStrokeWidth(2 * MAX_DISTANCE);
+			return fatPath.contains(pPoint.getX(), pPoint.getY());
+		}
+		
+	}
+
+	@Override
+	public Line getConnectionPoints(Edge pEdge) 
+	{
+		return new Line(getStoredEdgePath(pEdge).getStartPoint(), 
+				getStoredEdgePath(pEdge).getEndPoint());
+	}
+	
+	
+	/**
+	 * Gets the EdgePath of pEdge from EdgeStorage.
+	 * @param pEdge the edge of interest
+	 * @return the EdgePath of pEdge from storage
+	 * @pre pEdge is present in EdgeStorage
+	 */
+	private EdgePath getStoredEdgePath(Edge pEdge)
+	{
+		ClassDiagramViewer classDiagramViewer = (ClassDiagramViewer) DiagramType.viewerFor(pEdge.getDiagram());
+		assert classDiagramViewer.storageContains(pEdge);
+		return classDiagramViewer.storedEdgePath(pEdge);
+	}
+}

--- a/test/ca/mcgill/cs/jetuml/geom/TestEdgePath.java
+++ b/test/ca/mcgill/cs/jetuml/geom/TestEdgePath.java
@@ -1,0 +1,71 @@
+package ca.mcgill.cs.jetuml.geom;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the EdgePath class
+ */
+public class TestEdgePath 
+{
+	private final Point pointA = new Point(0,0);
+	private final Point pointB = new Point(200,0);
+	private final Point pointC = new Point(200,200);
+	private final Point pointD = new Point(300,200);
+	private EdgePath aEdgePath;
+	
+	@BeforeEach
+	public void setUp()
+	{
+		aEdgePath = new EdgePath(pointA, pointB, pointC, pointD);
+	}
+	
+	@Test
+	public void testGetStartPoint()
+	{
+		assertSame(pointA, aEdgePath.getStartPoint());
+	}
+	
+	@Test
+	public void testGetEndPoint()
+	{
+		assertSame(pointD, aEdgePath.getEndPoint());
+	}
+	
+	@Test
+	public void testGetPointByIndex()
+	{
+		assertSame(pointA, aEdgePath.getPointByIndex(0));
+		assertSame(pointB, aEdgePath.getPointByIndex(1));
+		assertSame(pointC, aEdgePath.getPointByIndex(2));
+		assertSame(pointD, aEdgePath.getPointByIndex(3));
+	}
+	
+	
+	@Test
+	public void testEquals()
+	{
+		EdgePath samePath = new EdgePath(pointA, pointB, new Point(200, 200), pointD);
+		EdgePath reversePath = new EdgePath(pointD, pointC, pointB, pointA);
+		EdgePath nullEdgePath = null;
+		assertTrue(samePath.equals(samePath));
+		assertTrue(samePath.equals(aEdgePath));
+		assertFalse(reversePath.equals(aEdgePath));
+		assertFalse(samePath.equals(nullEdgePath));
+		assertFalse(samePath.equals(new Point(0, 0)));
+		assertFalse(samePath.equals(new EdgePath(pointA, pointB, new Point(200, 200))));
+	}
+	
+	
+	
+	 @Test
+	 public void testSize()
+	 {
+		 assertTrue(aEdgePath.size() == 4);
+	 }
+	 
+	
+}

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestEdgeStorage.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestEdgeStorage.java
@@ -1,0 +1,146 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Point;
+
+/**
+ * Tests the EdgeStorage class.
+ */
+public class TestEdgeStorage 
+{
+	private EdgeStorage aEdgeStorage;
+	private Diagram aDiagram;
+	private Edge edge1;
+	private Edge edge2;
+	private Edge edge3;
+	private EdgePath path1;
+	private EdgePath path2;
+	private EdgePath path3;
+	private Node nodeA;
+	private Node nodeB;
+	private Node nodeC;
+	
+	@BeforeEach
+	private void setUp()
+	{
+		edge1 = new AggregationEdge();
+		edge2 = new DependencyEdge();
+		edge3 = new GeneralizationEdge();
+		path1 = new EdgePath(new Point(0,0), new Point(0, 100), new Point(100, 100), new Point(200, 100));
+		path2 = new EdgePath(new Point(300,300), new Point(300,350));
+		path3 = new EdgePath(new Point(0,200), new Point(200, 200), new Point(200, 100), new Point(100, 100));
+		aEdgeStorage = new EdgeStorage();
+		aDiagram = new Diagram(null);
+		nodeA = new ClassNode();
+		nodeB = new ClassNode();
+		nodeC = new ClassNode();
+	}
+	
+	@Test
+	public void testContains()
+	{
+		aEdgeStorage.store(edge1, path1);
+		assertTrue(aEdgeStorage.contains(edge1));
+		assertFalse(aEdgeStorage.contains(edge3));
+	}
+	
+	
+	@Test
+	public void testGetEdgePath()
+	{
+		aEdgeStorage.store(edge1, path1);
+		assertSame(aEdgeStorage.getEdgePath(edge1), path1);
+	}
+	
+	
+	@Test
+	public void testStore()
+	{
+		assertFalse(aEdgeStorage.contains(edge3));
+		aEdgeStorage.store(edge3, path3);
+		assertSame(aEdgeStorage.getEdgePath(edge3), path3);
+		aEdgeStorage.store(edge3, path1);
+		assertSame(aEdgeStorage.getEdgePath(edge3), path1);
+		
+	}
+	
+	@Test
+	public void testEdgesConnectedTo()
+	{
+		nodeA = new ClassNode();
+		nodeB = new ClassNode();
+		nodeC = new ClassNode();
+		edge1.connect(nodeB, nodeA, aDiagram);
+		edge2.connect(nodeA, nodeC, aDiagram);
+		edge3.connect(nodeB, nodeC, aDiagram);
+		aEdgeStorage.store(edge1, path1);
+		aEdgeStorage.store(edge2, path2);
+		aEdgeStorage.store(edge3, path3);
+		List<Edge> edgesConnectedToNodeA = aEdgeStorage.edgesConnectedTo(nodeA);
+		assertTrue(edgesConnectedToNodeA.contains(edge1));
+		assertTrue(edgesConnectedToNodeA.contains(edge2));
+		assertFalse(edgesConnectedToNodeA.contains(edge3));
+	}
+	@Test
+	public void testIsEmpty()
+	{
+		assertTrue(aEdgeStorage.isEmpty());
+		aEdgeStorage.store(edge1, path1);
+		assertFalse(aEdgeStorage.isEmpty());
+	}
+	
+	@Test
+	public void testConnectionPointIsAvailable()
+	{
+		aEdgeStorage.store(edge1, path1);
+		aEdgeStorage.store(edge2, path2);
+		aEdgeStorage.store(edge3, path3);
+		assertTrue(aEdgeStorage.connectionPointIsAvailable(new Point(1,1)));
+		assertTrue(aEdgeStorage.connectionPointIsAvailable(new Point(200,200)));
+		assertFalse(aEdgeStorage.connectionPointIsAvailable(new Point(0,0)));
+		assertFalse(aEdgeStorage.connectionPointIsAvailable(new Point(100,100)));
+	}
+	
+	@Test
+	public void testEdgesWithSameNodes()
+	{
+		nodeA = new ClassNode();
+		nodeB = new ClassNode();
+		edge1.connect(nodeB, nodeA, aDiagram);
+		edge2.connect(nodeA, nodeB, aDiagram);
+		edge3.connect(nodeC, nodeB, aDiagram);
+		aEdgeStorage.store(edge1, path1);
+		aEdgeStorage.store(edge2, path2);
+		aEdgeStorage.store(edge3, path3);
+		List<Edge> sameNodes = aEdgeStorage.getEdgesWithSameNodes(edge1);
+		assertTrue(sameNodes.size() == 1);
+		assertTrue(sameNodes.contains(edge2));
+	}
+	
+	@Test
+	public void testClearStorage()
+	{
+		aEdgeStorage.store(edge1, path1);
+		aEdgeStorage.store(edge2, path2);
+		aEdgeStorage.store(edge3, path3);
+		aEdgeStorage.clearStorage();
+		assertFalse(aEdgeStorage.contains(edge1));
+		assertFalse(aEdgeStorage.contains(edge2));
+		assertFalse(aEdgeStorage.contains(edge3));
+	}
+	
+	
+}

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestNodeIndex.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestNodeIndex.java
@@ -1,0 +1,120 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.Line;
+import ca.mcgill.cs.jetuml.geom.Point;
+
+/**
+ * Test for the NodeIndex methods. 
+ */
+public class TestNodeIndex 
+{
+	private final Node aNode = new ClassNode();
+	private final Diagram aDiagram = new Diagram(DiagramType.CLASS);
+	
+	
+	@BeforeEach
+	private void setUp()
+	{
+		aDiagram.addRootNode(aNode);
+		aNode.moveTo(new Point(0, 0));
+	}
+	
+	@Test
+	public void testToPoint_north()
+	{
+		Line nodeFace = new Line(new Point(0, 0), new Point(100, 0));
+		assertEquals(new Point(30, 0), NodeIndex.toPoint(nodeFace, Direction.NORTH, NodeIndex.MINUS_TWO));
+		assertEquals(new Point(50, 0), NodeIndex.toPoint(nodeFace, Direction.NORTH, NodeIndex.ZERO));
+		assertEquals(new Point(90, 0), NodeIndex.toPoint(nodeFace, Direction.NORTH, NodeIndex.PLUS_FOUR));
+	}
+	
+	@Test
+	public void testToPoint_south()
+	{
+		Line nodeFace = new Line(new Point(0, 60), new Point(100, 60));
+		assertEquals(new Point(30, 60), NodeIndex.toPoint(nodeFace, Direction.SOUTH, NodeIndex.MINUS_TWO));
+		assertEquals(new Point(50, 60), NodeIndex.toPoint(nodeFace, Direction.SOUTH, NodeIndex.ZERO));
+		assertEquals(new Point(90, 60), NodeIndex.toPoint(nodeFace, Direction.SOUTH, NodeIndex.PLUS_FOUR));
+	}
+	
+	@Test
+	public void testToPoint_west()
+	{
+		Line nodeFace = new Line(new Point(0, 0), new Point(0, 60));
+		assertEquals(new Point(0, 10), NodeIndex.toPoint(nodeFace, Direction.WEST, NodeIndex.MINUS_TWO));
+		assertEquals(new Point(0, 30), NodeIndex.toPoint(nodeFace, Direction.WEST, NodeIndex.ZERO));
+		assertEquals(new Point(0, 40), NodeIndex.toPoint(nodeFace, Direction.WEST, NodeIndex.PLUS_ONE));
+	}
+	
+	@Test
+	public void testToPoint_east()
+	{
+		Line nodeFace = new Line(new Point(100, 0), new Point(100, 60));
+		assertEquals(new Point(100, 10), NodeIndex.toPoint(nodeFace, Direction.EAST, NodeIndex.MINUS_TWO));
+		assertEquals(new Point(100, 30), NodeIndex.toPoint(nodeFace, Direction.EAST, NodeIndex.ZERO));
+		assertEquals(new Point(100, 40), NodeIndex.toPoint(nodeFace, Direction.EAST, NodeIndex.PLUS_ONE));
+	}
+	
+	@Test
+	public void testSpaceBetweenConnectionPoints_north()
+	{
+		Line regularSize = new Line(new Point(0, 0), new Point(100, 0));
+		Line largerSize = new Line(new Point(0, 0), new Point(200, 0));
+		assertEquals(10.0, spaceBetweenConnectionPoints(regularSize, Direction.NORTH));
+		assertEquals(20.0, spaceBetweenConnectionPoints(largerSize, Direction.NORTH));
+	}
+	
+	@Test
+	public void testSpaceBetweenConnectionPoints_south()
+	{
+		Line regularSize = new Line(new Point(0, 0), new Point(100, 0));
+		Line largerSize = new Line(new Point(0, 0), new Point(200, 0));
+		assertEquals(10.0, spaceBetweenConnectionPoints(regularSize, Direction.SOUTH));
+		assertEquals(20.0, spaceBetweenConnectionPoints(largerSize, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testSpaceBetweenConnectionPoints_east()
+	{
+		Line regularSize = new Line(new Point(0, 0), new Point(0, 60));
+		Line largerSize = new Line(new Point(0, 0), new Point(0, 120));
+		assertEquals(10.0, spaceBetweenConnectionPoints(regularSize, Direction.EAST));
+		assertEquals(20.0, spaceBetweenConnectionPoints(largerSize, Direction.EAST));
+	}
+	
+	@Test
+	public void testSpaceBetweenConnectionPoints_west()
+	{
+		Line regularSize = new Line(new Point(0, 0), new Point(0, 60));
+		Line largerSize = new Line(new Point(0, 0), new Point(0, 120));
+		assertEquals(10.0, spaceBetweenConnectionPoints(regularSize, Direction.WEST));
+		assertEquals(20.0, spaceBetweenConnectionPoints(largerSize, Direction.WEST));
+	}
+	
+	private static float spaceBetweenConnectionPoints(Line pNodeFace, Direction pAttachmentSide)
+	{
+		try
+		{
+			Method method = NodeIndex.class.getDeclaredMethod("spaceBetweenConnectionPoints", Line.class, Direction.class);
+			method.setAccessible(true);
+			return (float) method.invoke(null, pNodeFace, pAttachmentSide);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			e.printStackTrace();
+			fail();
+			return -1;
+		}
+	}
+	
+}

--- a/test/ca/mcgill/cs/jetuml/viewers/edges/TestStoredEdgeViewer.java
+++ b/test/ca/mcgill/cs/jetuml/viewers/edges/TestStoredEdgeViewer.java
@@ -1,0 +1,328 @@
+package ca.mcgill.cs.jetuml.viewers.edges;
+
+import ca.mcgill.cs.jetuml.geom.Point;
+import java.lang.reflect.Method;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge.Directionality;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.viewers.ArrowHead;
+import ca.mcgill.cs.jetuml.viewers.ClassDiagramViewer;
+import ca.mcgill.cs.jetuml.viewers.LineStyle;
+
+/**
+ * Tests the StoredEdgeViewer class.
+ */
+public class TestStoredEdgeViewer 
+{
+	private final Diagram aDiagram = new Diagram(DiagramType.CLASS);
+	private static final StoredEdgeViewer aStoredEdgeViewer = new StoredEdgeViewer();
+	private GeneralizationEdge aInheritanceEdge;
+	private GeneralizationEdge aImplementationEdge;
+	private AggregationEdge aAggregationEdge;
+	private AggregationEdge aCompositionEdge;
+	private AssociationEdge aAssociationEdge;
+	private DependencyEdge aDependencyEdge;
+	private ClassNode aNodeA;
+	private ClassNode aNodeB;
+	
+	@BeforeEach
+	public void setUp()
+	{
+		aInheritanceEdge = new GeneralizationEdge(GeneralizationEdge.Type.Inheritance);
+		aImplementationEdge = new GeneralizationEdge(GeneralizationEdge.Type.Implementation);
+		aAggregationEdge = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		aCompositionEdge = new AggregationEdge(AggregationEdge.Type.Composition);
+		aAssociationEdge = new AssociationEdge();
+		aDependencyEdge = new DependencyEdge();
+		aNodeA = new ClassNode();
+		aNodeB = new ClassNode();
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		
+	}
+
+	
+	@Test
+	public void testGetLineStyle()
+	{
+		assertEquals(LineStyle.SOLID, getLineStyle(aInheritanceEdge));
+		assertEquals(LineStyle.DOTTED, getLineStyle(aImplementationEdge));
+		assertEquals(LineStyle.SOLID, getLineStyle(aAggregationEdge));
+		assertEquals(LineStyle.SOLID, getLineStyle(aCompositionEdge));
+		assertEquals(LineStyle.SOLID, getLineStyle(aAssociationEdge));
+		assertEquals(LineStyle.DOTTED, getLineStyle(aDependencyEdge));
+	}
+	
+	@Test
+	public void testGetArrowStart_aggregation()
+	{
+		assertEquals(ArrowHead.DIAMOND, getArrowStart(aAggregationEdge));
+		assertEquals(ArrowHead.BLACK_DIAMOND, getArrowStart(aCompositionEdge));
+	}
+	
+	@Test
+	public void testGetArrowStart_generalization()
+	{
+		assertEquals(ArrowHead.NONE, getArrowStart(aInheritanceEdge));
+		assertEquals(ArrowHead.NONE, getArrowStart(aImplementationEdge));
+	}
+	
+	@Test
+	public void testGetArrowStart_association()
+	{
+		assertEquals(ArrowHead.NONE, getArrowStart(aAssociationEdge));
+		aAssociationEdge.setDirectionality(Directionality.Unidirectional);
+		assertEquals(ArrowHead.NONE, getArrowStart(aAssociationEdge));
+		aAssociationEdge.setDirectionality(Directionality.Bidirectional);
+		assertEquals(ArrowHead.V, getArrowStart(aAssociationEdge));
+	}
+	
+	@Test
+	public void testGetArrowStart_dependency()
+	{
+		assertEquals(ArrowHead.NONE, getArrowStart(aDependencyEdge));
+		aDependencyEdge.setDirectionality(DependencyEdge.Directionality.Unidirectional);
+		assertEquals(ArrowHead.NONE, getArrowStart(aDependencyEdge));
+		aDependencyEdge.setDirectionality(DependencyEdge.Directionality.Bidirectional);
+		assertEquals(ArrowHead.V, getArrowStart(aDependencyEdge));
+	}
+	
+	@Test
+	public void testGetArrowEnd_aggregation()
+	{
+		assertEquals(ArrowHead.NONE, getArrowEnd(aAggregationEdge));
+		assertEquals(ArrowHead.NONE, getArrowEnd(aCompositionEdge));
+	}
+	
+	@Test
+	public void testGetArrowEnd_generalization()
+	{
+		assertEquals(ArrowHead.TRIANGLE, getArrowEnd(aInheritanceEdge));
+		assertEquals(ArrowHead.TRIANGLE, getArrowEnd(aImplementationEdge));
+	}
+	
+	@Test
+	public void testGetArrowEnd_association()
+	{
+		assertEquals(ArrowHead.NONE, getArrowEnd(aAssociationEdge));
+		aAssociationEdge.setDirectionality(Directionality.Unidirectional);
+		assertEquals(ArrowHead.V, getArrowEnd(aAssociationEdge));
+		aAssociationEdge.setDirectionality(Directionality.Bidirectional);
+		assertEquals(ArrowHead.V, getArrowEnd(aAssociationEdge));
+	}
+	
+	@Test
+	public void testGetArrowEnd_dependency()
+	{
+		assertEquals(ArrowHead.V, getArrowEnd(aDependencyEdge));
+		aDependencyEdge.setDirectionality(DependencyEdge.Directionality.Bidirectional);
+		assertEquals(ArrowHead.V, getArrowEnd(aDependencyEdge));
+	}
+	
+	@Test
+	public void testgetStartLabel()
+	{
+		aAggregationEdge.setStartLabel("test");
+		aCompositionEdge.setStartLabel("test");
+		aAssociationEdge.setStartLabel("test");
+		assertEquals("", getStartLabel(aInheritanceEdge));
+		assertEquals("", getStartLabel(aImplementationEdge));
+		assertEquals("", getStartLabel(aDependencyEdge));
+		assertEquals("test", getStartLabel(aAggregationEdge));
+		assertEquals("test", getStartLabel(aCompositionEdge));
+		assertEquals("test", getStartLabel(aAssociationEdge));
+	}
+
+	@Test
+	public void testgetMiddleLabel()
+	{
+		aAggregationEdge.setMiddleLabel("test");
+		aCompositionEdge.setMiddleLabel("test");
+		aAssociationEdge.setMiddleLabel("test");
+		aDependencyEdge.setMiddleLabel("test");
+		assertEquals("", getMiddleLabel(aInheritanceEdge));
+		assertEquals("", getMiddleLabel(aImplementationEdge));
+		assertEquals("test", getMiddleLabel(aDependencyEdge));
+		assertEquals("test", getMiddleLabel(aAggregationEdge));
+		assertEquals("test", getMiddleLabel(aCompositionEdge));
+		assertEquals("test", getMiddleLabel(aAssociationEdge));
+	}
+	
+	@Test
+	public void testgetEndLabel()
+	{
+		aAssociationEdge.setEndLabel("test");
+		aAggregationEdge.setEndLabel("test");
+		aCompositionEdge.setEndLabel("test");
+		aAssociationEdge.setEndLabel("test");
+		assertEquals("", getEndLabel(aInheritanceEdge));
+		assertEquals("", getEndLabel(aImplementationEdge));
+		assertEquals("", getEndLabel(aDependencyEdge));
+		assertEquals("test", getEndLabel(aAggregationEdge));
+		assertEquals("test", getEndLabel(aCompositionEdge));
+		assertEquals("test", getEndLabel(aAssociationEdge));
+	}
+
+	
+	@Test
+	public void testContains()
+	{
+		aDependencyEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aDependencyEdge);
+		store(aDependencyEdge, new EdgePath(new Point(0, 0), new Point(0, 100)));
+		assertTrue(aStoredEdgeViewer.contains(aDependencyEdge, new Point(0, 50)));
+		assertTrue(aStoredEdgeViewer.contains(aDependencyEdge, new Point(1, 1)));
+		assertFalse(aStoredEdgeViewer.contains(aDependencyEdge, new Point(10, 50)));
+	}
+
+	@Test
+	public void testGetConnectionPoints()
+	{
+		aDependencyEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aDependencyEdge);
+		store(aDependencyEdge, new EdgePath(new Point(0, 0), new Point(0, 100)));
+		assertEquals(new Point(0, 0), aStoredEdgeViewer.getConnectionPoints(aDependencyEdge).getPoint1());
+		assertEquals(new Point(0, 100), aStoredEdgeViewer.getConnectionPoints(aDependencyEdge).getPoint2());
+	}
+	
+	@Test
+	public void testGetStoredEdgePath()
+	{
+		aDependencyEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aDependencyEdge);
+		store(aDependencyEdge, new EdgePath(new Point(0, 0), new Point(0, 100)));
+		assertEquals(new EdgePath(new Point(0, 0), new Point(0, 100)), getStoredEdgePath(aDependencyEdge));
+	}
+	
+	
+	
+	
+	
+	/// Private reflexive helper methods:
+	
+	private static LineStyle getLineStyle(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getLineStyle", Edge.class);
+			method.setAccessible(true);
+			return (LineStyle) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static ArrowHead getArrowStart(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getArrowStart", Edge.class);
+			method.setAccessible(true);
+			return (ArrowHead) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+
+	private static ArrowHead getArrowEnd(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getArrowEnd", Edge.class);
+			method.setAccessible(true);
+			return (ArrowHead) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private String getStartLabel(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getStartLabel", Edge.class);
+			method.setAccessible(true);
+			return (String) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private String getMiddleLabel(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getMiddleLabel", Edge.class);
+			method.setAccessible(true);
+			return (String) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private String getEndLabel(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getEndLabel", Edge.class);
+			method.setAccessible(true);
+			return (String) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private EdgePath getStoredEdgePath(Edge pEdge)
+	{
+		try
+		{
+			Method method = StoredEdgeViewer.class.getDeclaredMethod("getStoredEdgePath", Edge.class);
+			method.setAccessible(true);
+			return (EdgePath) method.invoke(aStoredEdgeViewer, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	
+	private void store(Edge pEdge, EdgePath pEdgePath)
+	{
+		ClassDiagramViewer viewer = (ClassDiagramViewer) DiagramType.viewerFor(aDiagram);
+		viewer.store(pEdge, pEdgePath);
+	}
+	
+}

--- a/test/ca/mcgill/cs/jetuml/views/TestClassDiagramViewer.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestClassDiagramViewer.java
@@ -1,0 +1,104 @@
+package ca.mcgill.cs.jetuml.views;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.viewers.ClassDiagramViewer;
+
+/**
+ * Tests for ClassDiagramViewer 
+ *
+ */
+public class TestClassDiagramViewer 
+{
+	private final Diagram aDiagram = new Diagram(DiagramType.CLASS);
+	private ClassDiagramViewer aClassDiagramViewer;
+	private GeneralizationEdge aImplementationEdge;
+	private AggregationEdge aAggregationEdge;
+	private DependencyEdge aDependencyEdge;
+	private ClassNode aNodeA;
+	private ClassNode aNodeB;
+	
+	/**
+	 * Connects aDependencyEdge from aNodeB to aNodeA and stores its EdgePath in storage.
+	 */
+	private void setUpAndStoreDependencyEdge()
+	{
+		aDependencyEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aDependencyEdge);
+		aClassDiagramViewer.store(aDependencyEdge, new EdgePath(new Point(0, 0), new Point(0, 100)));
+	}
+	@BeforeEach
+	public void setUp()
+	{
+		aClassDiagramViewer = (ClassDiagramViewer) DiagramType.viewerFor(aDiagram);
+		aImplementationEdge = new GeneralizationEdge(GeneralizationEdge.Type.Implementation);
+		aAggregationEdge = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		aDependencyEdge = new DependencyEdge();
+		aNodeA = new ClassNode();
+		aNodeB = new ClassNode();
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+	}
+	
+	@Test
+	public void testConnectionPointAvailableInStorage()
+	{
+		setUpAndStoreDependencyEdge();
+		assertFalse(aClassDiagramViewer.connectionPointAvailableInStorage(new Point(0, 0)));
+		assertFalse(aClassDiagramViewer.connectionPointAvailableInStorage(new Point(0, 100)));
+		assertTrue(aClassDiagramViewer.connectionPointAvailableInStorage(new Point(0, 50)));
+	}
+	
+	@Test
+	public void testStoredEdgesWithSameNodes()
+	{
+		aImplementationEdge.connect(aNodeB, aNodeA, aDiagram);
+		aAggregationEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aImplementationEdge);
+		aDiagram.addEdge(aAggregationEdge);
+		aClassDiagramViewer.store(aImplementationEdge, new EdgePath(new Point(0, 0), new Point(0, 100), new Point(100, 100), new Point(200, 100)));
+		List<Edge> result = aClassDiagramViewer.storedEdgesWithSameNodes(aAggregationEdge);
+		assertTrue(result.size() == 1);
+		assertTrue(result.contains(aImplementationEdge));
+	}
+	
+	@Test
+	public void testStoredEdgesConnctedTo()
+	{
+		setUpAndStoreDependencyEdge();
+		List<Edge> result = aClassDiagramViewer.storedEdgesConnectedTo(aNodeA);
+		assertTrue(result.size() == 1);
+		assertEquals(aDependencyEdge, result.get(0));
+	}
+	
+	@Test
+	public void testStorageContains()
+	{
+		setUpAndStoreDependencyEdge();
+		assertTrue(aClassDiagramViewer.storageContains(aDependencyEdge));
+		assertFalse(aClassDiagramViewer.storageContains(aImplementationEdge));
+		
+	}
+	
+	@Test
+	public void testStoredEdgePath()
+	{
+		setUpAndStoreDependencyEdge();
+		assertEquals(new EdgePath(new Point(0, 0), new Point(0, 100)), aClassDiagramViewer.storedEdgePath(aDependencyEdge));
+	}
+	
+}

--- a/test/ca/mcgill/cs/jetuml/views/TestEdgePriority.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestEdgePriority.java
@@ -1,0 +1,132 @@
+package ca.mcgill.cs.jetuml.views;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge.Type;
+import ca.mcgill.cs.jetuml.diagram.edges.NoteEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.viewers.EdgePriority;
+
+public class TestEdgePriority 
+{
+	private Diagram aDiagram = new Diagram(DiagramType.CLASS);
+	private Edge aInheritanceEdge = new GeneralizationEdge(Type.Inheritance);
+	private Edge aImplementationEdge = new GeneralizationEdge(Type.Implementation);
+	private Edge aAggregationEdge = new AggregationEdge(AggregationEdge.Type.Aggregation);
+	private Edge aCompositionEdge = new AggregationEdge(AggregationEdge.Type.Composition);
+	private Edge aAssociationEdge = new AssociationEdge();
+	private Edge aDependencyEdge = new DependencyEdge();
+	private Edge aSelfEdge = new AggregationEdge(AggregationEdge.Type.Composition);
+	private Edge aNoteEdge = new NoteEdge();
+	private Node aNode1 = new ClassNode();
+	
+	
+	@BeforeEach
+	private void setUp()
+	{
+		aSelfEdge.connect(aNode1, aNode1, aDiagram);
+	}
+	
+	@Test
+	public void testPriorityOf_inheritance()
+	{
+		assertEquals(EdgePriority.priorityOf(aInheritanceEdge), EdgePriority.INHERITANCE);
+	}
+	
+	@Test
+	public void testPriorityOf_implementation()
+	{
+		assertEquals(EdgePriority.priorityOf(aImplementationEdge), EdgePriority.IMPLEMENTATION);
+	}
+	
+	@Test
+	public void testPriorityOf_aggregation()
+	{
+		assertEquals(EdgePriority.priorityOf(aAggregationEdge), EdgePriority.AGGREGATION);
+	}
+	
+	@Test
+	public void testPriorityOf_composition()
+	{
+		assertEquals(EdgePriority.priorityOf(aCompositionEdge), EdgePriority.COMPOSITION);
+	}
+	
+	@Test
+	public void testPriorityOf_association()
+	{
+		assertEquals(EdgePriority.priorityOf(aAssociationEdge), EdgePriority.ASSOCIATION);
+	}
+	
+	@Test
+	public void testPriorityOf_dependency()
+	{
+		assertEquals(EdgePriority.priorityOf(aDependencyEdge), EdgePriority.DEPENDENCY);
+	}
+	
+	@Test
+	public void testPriorityOf_selfEdge()
+	{
+		assertEquals(EdgePriority.priorityOf(aSelfEdge), EdgePriority.SELF_EDGE);
+	}
+	
+	@Test
+	public void testPriorityOf_other()
+	{
+		assertEquals(EdgePriority.priorityOf(aNoteEdge), EdgePriority.OTHER);
+	}
+	
+	@Test
+	public void testIsSegmented_givenPriority()
+	{
+		assertTrue(EdgePriority.isSegmented(EdgePriority.INHERITANCE));
+		assertTrue(EdgePriority.isSegmented(EdgePriority.IMPLEMENTATION));
+		assertTrue(EdgePriority.isSegmented(EdgePriority.AGGREGATION));
+		assertTrue(EdgePriority.isSegmented(EdgePriority.COMPOSITION));
+		assertTrue(EdgePriority.isSegmented(EdgePriority.ASSOCIATION));
+		assertFalse(EdgePriority.isSegmented(EdgePriority.DEPENDENCY));
+		assertFalse(EdgePriority.isSegmented(EdgePriority.OTHER));
+		assertFalse(EdgePriority.isSegmented(EdgePriority.SELF_EDGE));
+	}
+	
+	@Test
+	public void testIsSegmented_givenEdge()
+	{
+		assertTrue(EdgePriority.isSegmented(aInheritanceEdge));
+		assertTrue(EdgePriority.isSegmented(aImplementationEdge));
+		assertTrue(EdgePriority.isSegmented(aAggregationEdge));
+		assertTrue(EdgePriority.isSegmented(aCompositionEdge));
+		assertTrue(EdgePriority.isSegmented(aAssociationEdge));
+		assertFalse(EdgePriority.isSegmented(aDependencyEdge));
+		assertFalse(EdgePriority.isSegmented(aSelfEdge));
+		assertFalse(EdgePriority.isSegmented(aNoteEdge));
+	}
+	
+	@Test
+	public void testIsClassDiagramEdge()
+	{
+		assertTrue(EdgePriority.isStoredEdge(aInheritanceEdge));
+		assertTrue(EdgePriority.isStoredEdge(aImplementationEdge));
+		assertTrue(EdgePriority.isStoredEdge(aAggregationEdge));
+		assertTrue(EdgePriority.isStoredEdge(aCompositionEdge));
+		assertTrue(EdgePriority.isStoredEdge(aAssociationEdge));
+		assertTrue(EdgePriority.isStoredEdge(aDependencyEdge));
+		assertTrue(EdgePriority.isStoredEdge(aSelfEdge));
+		assertFalse(EdgePriority.isStoredEdge(aNoteEdge));
+	}
+
+}
+

--- a/test/ca/mcgill/cs/jetuml/views/TestLayouter.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestLayouter.java
@@ -1,0 +1,3004 @@
+package ca.mcgill.cs.jetuml.views;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge.Type;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Edge;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.edges.AggregationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.AssociationEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.DependencyEdge;
+import ca.mcgill.cs.jetuml.diagram.edges.GeneralizationEdge;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.EdgePath;
+import ca.mcgill.cs.jetuml.geom.Line;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.geom.Rectangle;
+import ca.mcgill.cs.jetuml.viewers.ClassDiagramViewer;
+import ca.mcgill.cs.jetuml.viewers.EdgePriority;
+import ca.mcgill.cs.jetuml.viewers.Layouter;
+import ca.mcgill.cs.jetuml.viewers.NodeCorner;
+import ca.mcgill.cs.jetuml.viewers.edges.EdgeStorage;
+
+/**
+ * Tests the Layouter class methods.
+ */
+public class TestLayouter 
+{
+	private Diagram aDiagram;
+	
+	private static final Layouter aLayouter = new Layouter();
+	private Node aNodeA;
+	private Node aNodeB;
+	private Node aNodeC;
+	private Node aNodeD;
+	private Node aNodeE;
+	private Node aNodeF;
+	private Node aNodeG;
+	private Node endNode;
+	private Edge dependencyEdge;
+	private Edge generalizationEdge;
+	
+	private Edge aEdgeA;
+	private Edge aEdgeB;
+	private Edge aEdgeC;
+	private Edge aEdgeD;
+	private Edge aEdgeE;
+	private Edge aEdgeF;
+	private Edge aEdgeG;
+	
+	private Rectangle aRectangleA;
+	private Rectangle aRectangleB;
+	private Rectangle aRectangleC;
+	
+	@BeforeEach
+	public void setup()
+	{
+		aDiagram = new Diagram(DiagramType.CLASS);
+		aNodeA = new ClassNode();
+		aNodeB = new ClassNode();
+		aNodeC = new ClassNode();
+		aNodeD = new ClassNode();
+		aNodeE = new ClassNode();
+		aNodeF = new ClassNode();
+		aNodeG = new ClassNode();
+		aEdgeA = new GeneralizationEdge();
+		aEdgeB = new GeneralizationEdge();
+		aEdgeC = new GeneralizationEdge();
+		aEdgeD = new GeneralizationEdge();
+		aEdgeE = new GeneralizationEdge();
+		aRectangleA = new Rectangle(200, 200, 100, 60);
+		aRectangleB = new Rectangle(200, 150, 100, 60);
+		aRectangleC = new Rectangle(100, 200, 100, 60);
+	}
+	
+	
+	/**
+	 * Sets up two class nodes in the diagram which are connected by a generalization Edge. 
+	 * The required position of the nodes is unique for each test; nodes should be repositioned by individual test methods. 
+	 */
+	private void setUpTwoConnectedNodes()
+	{
+		aDiagram.addRootNode(aNodeA);//start node
+		aDiagram.addRootNode(aNodeB);//end node
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+	}
+	
+	/**
+	 * Sets up 3 nodes, where both aNodeB and aNodeC are below aNodeA, and their edges point towards aNodeA.
+	 * Nodes can be repositioned to suit different test cases.
+	 */
+	private void setUpThreeConnectedNodes()
+	{
+		 aDiagram.addRootNode(aNodeA);
+		 aDiagram.addRootNode(aNodeB);
+		 aDiagram.addRootNode(aNodeC);
+		
+		 aEdgeA.connect(aNodeB, aNodeA, aDiagram);
+		 aEdgeB.connect(aNodeC, aNodeA, aDiagram);
+		 
+		 aDiagram.addEdge(aEdgeA);
+		 aDiagram.addEdge(aEdgeB);
+		 aNodeA.moveTo(new Point(100, 140));
+		 aNodeB.moveTo(new Point(110, 300));
+		 aNodeC.moveTo(new Point(200, 300));
+	
+	}
+	
+	/**
+	 * Initializes 3 Aggregation Edges: aEdgeA, aEdgeB, aEdgeC
+	 * which are outgoing from aNodeD and incoming on aNodeA, aNodeB, aNodeC, respectively.
+	 * Nodes should be positioned by each test method. 
+	 */
+	private void setUpMergedStartEdges()
+	{
+		aDiagram.addRootNode(aNodeD);
+		aEdgeA = new AggregationEdge();
+		aEdgeB = new AggregationEdge();
+		aEdgeC = new AggregationEdge();
+		aEdgeD = new AggregationEdge();
+		aEdgeA.connect(aNodeD, aNodeA, aDiagram);
+		aEdgeB.connect(aNodeD, aNodeB, aDiagram);
+		aEdgeC.connect(aNodeD, aNodeC, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		aDiagram.addEdge(aEdgeB);
+		aDiagram.addEdge(aEdgeC);
+		
+	}
+	
+	/**
+	 * Sets up three Generalization edges: aEdgeA, aEdgeB, aEdgeC. These edges start 
+	 * at aNodeA, aNodeB, and aNodeC, receptively, and all end at aNodeD. 
+	 * Nodes should be positioned by each test method based on the test case. 
+	 */
+	private void setUpMergedEndEdges()
+	{
+		aEdgeA.connect(aNodeA, aNodeD, aDiagram);
+		aEdgeB.connect(aNodeB, aNodeD, aDiagram);
+		aEdgeC.connect(aNodeC, aNodeD, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		aDiagram.addEdge(aEdgeB);
+		aDiagram.addEdge(aEdgeC);
+	}
+	
+	/**
+	 * Used for LayoutDependencyEdge() test methods. 
+	 * 
+	 * Sets up a dependencyEdge connection aNodeB --> aNodeA 
+	 * and a GeneralizationEdge connecting aNodeC --> aNodeA.
+	 * Test methods should move nodes depending on the test scenario.
+	 */
+	private void setUpDependencyEdges()
+	{
+		dependencyEdge = new DependencyEdge();
+		generalizationEdge = new GeneralizationEdge();
+		dependencyEdge.connect(aNodeB, aNodeA, aDiagram);
+		generalizationEdge.connect(aNodeC, aNodeA, aDiagram);
+		aDiagram.addEdge(dependencyEdge);
+		aDiagram.addEdge(generalizationEdge);
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+	}
+	
+	/**
+	 * Sets up 5 nodes and 4 AggregationEdge edges of type pType
+	 * @param pType the AggregationEdge type (either Aggregation or Composition)
+	 * 
+	 * 	aNodeA and aNodeB are to the West of aNodeD.
+		aNodeC and aNodeE are South East of aNode.
+		aEdgeA, aEdgeB,  and aEdgeC are Aggregation Edges which start at aNodeD.
+		aEdgeD is a implementation edge connecting aNodeD <--- aNodeE, and is in storage.
+	 */
+	private void setUpLayoutMergedStartEdges(AggregationEdge.Type pType)
+	{
+		aEdgeA = new AggregationEdge(pType);
+		aEdgeB = new AggregationEdge(pType);
+		aEdgeC = new AggregationEdge(pType);
+		aEdgeD = new GeneralizationEdge();
+	
+		for (Node node : Arrays.asList(aNodeA, aNodeB, aNodeC, aNodeD, aNodeE))
+		{
+			aDiagram.addRootNode(node);
+		}
+		
+		aEdgeA.connect(aNodeD, aNodeA, aDiagram);
+		aEdgeB.connect(aNodeD, aNodeB, aDiagram);
+		aEdgeC.connect(aNodeD, aNodeC, aDiagram);
+		aEdgeD.connect(aNodeE, aNodeD, aDiagram);
+		for (Edge edge : Arrays.asList(aEdgeA, aEdgeB, aEdgeC, aEdgeD))
+		{
+			aDiagram.addEdge(edge);
+		}
+		
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(0, 120));
+		aNodeC.moveTo(new Point(400, 180));
+		aNodeD.moveTo(new Point(200, 60));
+		aNodeE.moveTo(new Point(400, 100));
+		
+		store(aEdgeD, new EdgePath(new Point(400, 130), new Point(350, 130), new Point(350, 90), new Point(300, 90)));	
+	}
+	
+	/**
+	 * Sets up 5 nodes and 4 edges for testing the Layouter.layoutMergedEndEdges() method.
+	 * <ul>
+	 * <li> aNodeA, aNodeB, aNodec, aNodeD are all South of endNode </li>
+	 * <li> aEdgeA, aEdgeB are inheritance edges connecting aNodeA, aNodeB (respectively) to endNode. </li>
+	 * <li> aEdgeC is an implementation edge connecting aNodeC to endNode. </li>
+	 * <li> aEdgeD is an association edge connecting aEdgeD to endNode. </li>
+	 * </ul>
+	 */
+	private void setUpLayoutMergedEndEdges()
+	{
+		endNode = new ClassNode();
+		aEdgeA = new GeneralizationEdge(Type.Inheritance);
+		aEdgeB = new GeneralizationEdge(Type.Inheritance);
+		aEdgeC = new GeneralizationEdge(Type.Implementation);
+		aEdgeD = new AssociationEdge();
+		for (Node node : Arrays.asList(aNodeA, aNodeB, aNodeC, aNodeD,endNode))
+		{
+			aDiagram.addRootNode(node);
+		}
+		aEdgeA.connect(aNodeA, endNode, aDiagram);
+		aEdgeB.connect(aNodeB, endNode, aDiagram);
+		aEdgeC.connect(aNodeC, endNode, aDiagram);
+		aEdgeD.connect(aNodeD, endNode, aDiagram);
+		
+		for (Edge edge : Arrays.asList(aEdgeA, aEdgeB, aEdgeC, aEdgeD))
+		{
+			aDiagram.addEdge(edge);
+		}
+		aNodeA.moveTo(new Point(0, 140));
+		aNodeB.moveTo(new Point(100, 140));
+		aNodeC.moveTo(new Point(200, 140));
+		aNodeD.moveTo(new Point(300, 140));
+		endNode.moveTo(new Point(0,0));
+	}
+	
+	/**
+	 * Sets up 7 edges of different priority types for testing Layouter.layout()
+	 */
+	private void setUpTestLayout()
+	{
+		endNode = new ClassNode();
+		aEdgeA = new GeneralizationEdge(Type.Inheritance);
+		aEdgeB = new GeneralizationEdge(Type.Inheritance);
+		aEdgeC = new GeneralizationEdge(Type.Implementation);
+		aEdgeD = new AssociationEdge();
+		aEdgeE = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		aEdgeF = new AggregationEdge(AggregationEdge.Type.Composition);
+		aEdgeG = new DependencyEdge();
+		for (Node node : Arrays.asList(aNodeA, aNodeB, aNodeC, aNodeD, aNodeE, aNodeF, aNodeG, endNode))
+		{
+			aDiagram.addRootNode(node);
+		}
+		aEdgeA.connect(aNodeA, endNode, aDiagram);
+		aEdgeB.connect(aNodeB, endNode, aDiagram);
+		aEdgeC.connect(aNodeC, endNode, aDiagram);
+		aEdgeD.connect(aNodeD, endNode, aDiagram);
+		aEdgeE.connect(aNodeE, endNode, aDiagram);
+		aEdgeF.connect(aNodeF, endNode, aDiagram);
+		aEdgeG.connect(aNodeG, endNode, aDiagram);
+		
+		for (Edge edge : Arrays.asList(aEdgeA, aEdgeB, aEdgeC, aEdgeD, aEdgeE, aEdgeF, aEdgeG))
+		{
+			aDiagram.addEdge(edge);
+		}
+		aNodeA.moveTo(new Point(0, 190));
+		aNodeB.moveTo(new Point(100, 190));
+		aNodeC.moveTo(new Point(200, 190));
+		aNodeD.moveTo(new Point(300, 190));
+		aNodeE.moveTo(new Point(400, 60));
+		aNodeF.moveTo(new Point(400, 0));
+		aNodeG.moveTo(new Point(0, 0));
+		endNode.moveTo(new Point(150,60));
+	}
+	
+	///// TESTS /////
+	
+	@Test
+	public void testLayout()
+	{
+		setUpTestLayout();
+		aLayouter.layout(aDiagram);
+		//aEdgeA
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(50, 190)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(50, 155)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(200, 155)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(200, 120)).get());
+		//aEdgeB (the other segments of aEdgeB overlap with aEdgeA)
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 190)).get());
+		//aEdgeC
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 190)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 155)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(210, 155)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(210, 120)).get());
+		//aEdgeD
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(350, 190)).get());
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(350, 145)).get());
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(220, 145)).get());
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(220, 120)).get());
+		//aEdgeE
+		assertEquals(aEdgeE, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(400, 90)).get());
+		assertEquals(aEdgeE, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 90)).get());
+		//EdgeF
+		assertEquals(aEdgeF, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(400, 30)).get());
+		assertEquals(aEdgeF, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(325, 30)).get());
+		assertEquals(aEdgeF, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(325, 80)).get());
+		assertEquals(aEdgeF, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 80)).get());
+		//aEdgeG
+		assertEquals(aEdgeG, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(100, 30)).get());
+		assertEquals(aEdgeG, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 90)).get());
+	}
+	
+	
+	@Test
+	public void testLayoutMergedEndEdges()
+	{
+		setUpLayoutMergedEndEdges();
+		//Layout aEdgeA and aEdgeB
+		layoutSegmentedEdges(aDiagram, EdgePriority.INHERITANCE);
+		assertTrue(storageContains(aEdgeA));
+		assertTrue(storageContains(aEdgeB));
+		assertFalse(storageContains(aEdgeC));
+		assertFalse(storageContains(aEdgeD));
+		//aEdgeA
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(50, 140)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(50, 100)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(50, 60)).get());
+		//aEdgeB
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 140)).get());
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 100)).get());
+		
+		//Layout aEdgeC
+		layoutSegmentedEdges(aDiagram, EdgePriority.IMPLEMENTATION);
+		assertTrue(storageContains(aEdgeA));
+		assertTrue(storageContains(aEdgeB));
+		assertTrue(storageContains(aEdgeC));
+		assertFalse(storageContains(aEdgeD));
+		//aEdgeC
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 140)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(250, 90)).get());
+		
+		//Layout aEdgeD
+		layoutSegmentedEdges(aDiagram, EdgePriority.ASSOCIATION);
+		assertTrue(storageContains(aEdgeA));
+		assertTrue(storageContains(aEdgeB));
+		assertTrue(storageContains(aEdgeC));
+		assertTrue(storageContains(aEdgeD));
+		//aEdgeD
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(350, 140)).get());
+		assertEquals(aEdgeD, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(350, 80)).get());
+		
+	}
+	
+	@Test
+	public void testLayoutSegmentedEdges_aggregation()
+	{
+		setUpLayoutMergedStartEdges(AggregationEdge.Type.Aggregation);
+		layoutSegmentedEdges(aDiagram, EdgePriority.AGGREGATION);
+		//aEdgeA
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(200, 90)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 90)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 30)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(100, 30)).get());
+		//aEdgeB
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 150)).get());
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(100, 150)).get());
+		//aEdgeC
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(300, 100)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(340, 100)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(340, 210)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(400, 210)).get());
+		
+	}
+	
+	@Test
+	public void testLayoutSegmentedEdges_composition()
+	{
+		setUpLayoutMergedStartEdges(AggregationEdge.Type.Composition);
+		layoutSegmentedEdges(aDiagram, EdgePriority.COMPOSITION);
+		//aEdgeA
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(200, 90)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 90)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 30)).get());
+		assertEquals(aEdgeA, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(100, 30)).get());
+		
+		//aEdgeB
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(150, 150)).get());
+		assertEquals(aEdgeB, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(100, 150)).get());
+		
+		//aEdgeC
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(300, 100)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(340, 100)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(340, 210)).get());
+		assertEquals(aEdgeC, DiagramType.viewerFor(aDiagram).edgeAt(aDiagram, new Point(400, 210)).get());
+		
+	}
+	
+	@Test
+	public void testStoreMergedEndEdges_north()
+	{
+		setUpMergedEndEdges();
+		//aNodeA, aNodeB, and aNodeC are South of aNodeD
+		//aEdgeA, aEdgeB, and aEdgeC are incoming on the South side of aNodeD
+		aNodeA.moveTo(new Point(0, 100));
+		aNodeB.moveTo(new Point(100, 100));
+		aNodeC.moveTo(new Point(200, 100));
+		aNodeD.moveTo(new Point(100, 0));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		EdgePath expectedPathA = new EdgePath(new Point(50, 100), new Point(50, 80), new Point(150, 80), new Point(150, 60));
+		EdgePath expectedPathB = new EdgePath(new Point(150, 100), new Point(150, 80), new Point(150, 80), new Point(150, 60));
+		EdgePath expectedPathC = new EdgePath(new Point(250, 100), new Point(250, 80), new Point(150, 80), new Point(150, 60));
+		storeMergedEndEdges(Direction.NORTH, edgesToMerge, aDiagram);
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedEndEdges_south()
+	{
+		setUpMergedEndEdges();
+		//aNodeA, aNodeB, and aNodeC are Nouth of aNodeD
+		//aEdgeA, aEdgeB, and aEdgeC are incoming on the Nouth side of aNodeD
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeC.moveTo(new Point(200, 0));
+		aNodeD.moveTo(new Point(100, 100));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		EdgePath expectedPathA = new EdgePath(new Point(50, 60), new Point(50, 80), new Point(150, 80), new Point(150, 100));
+		EdgePath expectedPathB = new EdgePath(new Point(150, 60), new Point(150, 80), new Point(150, 80), new Point(150, 100));
+		EdgePath expectedPathC = new EdgePath(new Point(250, 60), new Point(250, 80), new Point(150, 80), new Point(150, 100));
+		storeMergedEndEdges(Direction.SOUTH, edgesToMerge, aDiagram);
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedEndEdges_east()
+	{
+		setUpMergedEndEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the West of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are incoming on the West side of aNodeD.
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(0, 60));
+		aNodeC.moveTo(new Point(0, 120));
+		aNodeD.moveTo(new Point(200, 60));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedEndEdges(Direction.EAST, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(100, 30), new Point(150, 30), new Point(150, 90), new Point(200, 90));
+		EdgePath expectedPathB = new EdgePath(new Point(100, 90), new Point(150, 90), new Point(150, 90), new Point(200, 90));
+		EdgePath expectedPathC = new EdgePath(new Point(100, 150), new Point(150, 150), new Point(150, 90), new Point(200, 90));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedEndEdges_west()
+	{
+		setUpMergedEndEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the East of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are incoming on the East side of aNodeD.
+		aNodeA.moveTo(new Point(200, 0));
+		aNodeB.moveTo(new Point(200, 60));
+		aNodeC.moveTo(new Point(200, 120));
+		aNodeD.moveTo(new Point(0, 60));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedEndEdges(Direction.WEST, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(200, 30), new Point(150, 30), new Point(150, 90), new Point(100, 90));
+		EdgePath expectedPathB = new EdgePath(new Point(200, 90), new Point(150, 90), new Point(150, 90), new Point(100, 90));
+		EdgePath expectedPathC = new EdgePath(new Point(200, 150), new Point(150, 150), new Point(150, 90), new Point(100, 90));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedStartEdges_north()
+	{
+		setUpMergedStartEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the North of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are outgoing from the North side of aNodeD.
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeC.moveTo(new Point(200, 0));
+		aNodeD.moveTo(new Point(100, 100));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedStartEdges(Direction.NORTH, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(150, 100), new Point(150, 80), new Point(50, 80), new Point(50, 60));
+		EdgePath expectedPathB = new EdgePath(new Point(150, 100), new Point(150, 80), new Point(150, 80), new Point(150, 60));
+		EdgePath expectedPathC = new EdgePath(new Point(150, 100), new Point(150, 80), new Point(250, 80), new Point(250, 60));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+
+	@Test
+	public void testStoreMergedStartEdges_south()
+	{
+		setUpMergedStartEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the South of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are outgoing from the South side of aNodeD.
+		aNodeA.moveTo(new Point(0, 100));
+		aNodeB.moveTo(new Point(100, 100));
+		aNodeC.moveTo(new Point(200, 100));
+		aNodeD.moveTo(new Point(100, 0));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedStartEdges(Direction.SOUTH, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(150, 60), new Point(150, 80), new Point(50, 80), new Point(50, 100));
+		EdgePath expectedPathB = new EdgePath(new Point(150, 60), new Point(150, 80), new Point(150, 80), new Point(150, 100));
+		EdgePath expectedPathC = new EdgePath(new Point(150, 60), new Point(150, 80), new Point(250, 80), new Point(250, 100));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedStartEdges_west()
+	{
+		setUpMergedStartEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the West of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are outgoing from the West side of aNodeD.
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(0, 100));
+		aNodeC.moveTo(new Point(0, 200));
+		aNodeD.moveTo(new Point(200, 100));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedStartEdges(Direction.WEST, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(200, 130), new Point(150, 130), new Point(150, 30), new Point(100, 30));
+		EdgePath expectedPathB = new EdgePath(new Point(200, 130), new Point(150, 130), new Point(150, 130), new Point(100, 130));
+		EdgePath expectedPathC = new EdgePath(new Point(200, 130), new Point(150, 130), new Point(150, 230), new Point(100, 230));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testStoreMergedStartEdges_east()
+	{
+		setUpMergedStartEdges();
+		//aNodeA, aNodeB, and aNodeC are all to the East of aNodeD.
+		//aEgdeA, aEdgeB and aEdgeC are outgoing from the East side of aNodeD.
+		aNodeA.moveTo(new Point(200, 0));
+		aNodeB.moveTo(new Point(200, 100));
+		aNodeC.moveTo(new Point(200, 200));
+		aNodeD.moveTo(new Point(0, 100));
+		List<Edge> edgesToMerge = Arrays.asList(aEdgeA, aEdgeB, aEdgeC);
+		storeMergedStartEdges(Direction.EAST, edgesToMerge, aDiagram);
+		EdgePath expectedPathA = new EdgePath(new Point(100, 130), new Point(150, 130), new Point(150, 30), new Point(200, 30));
+		EdgePath expectedPathB = new EdgePath(new Point(100, 130), new Point(150, 130), new Point(150, 130), new Point(200, 130));
+		EdgePath expectedPathC = new EdgePath(new Point(100, 130), new Point(150, 130), new Point(150, 230), new Point(200, 230));
+		assertEquals(expectedPathA, getStoredEdgePath(aEdgeA));
+		assertEquals(expectedPathB, getStoredEdgePath(aEdgeB));
+		assertEquals(expectedPathC, getStoredEdgePath(aEdgeC));
+	}
+	
+	@Test
+	public void testLayoutDependencyEdges_noOtherEdges()
+	{
+		setUpDependencyEdges();
+		aNodeA.moveTo(new Point(0,0));
+		aNodeB.moveTo(new Point(100, 120));
+		layoutDependencyEdges(aDiagram);
+		assertEquals(new EdgePath(new Point(150, 120), new Point(50, 60)), getStoredEdgePath(dependencyEdge));
+	}
+	
+	@Test
+	public void testLayoutDependencyEdges_otherEdgePresent()
+	{
+		setUpDependencyEdges();
+		aNodeA.moveTo(new Point(0,0));
+		aNodeB.moveTo(new Point(200, 0));
+		store(generalizationEdge, new EdgePath(new Point(200, 90), new Point(150, 90), new Point(150, 30), new Point(100, 30)));
+		layoutDependencyEdges(aDiagram);
+		assertEquals(new EdgePath(new Point(200, 30), new Point(100, 40)), getStoredEdgePath(dependencyEdge));
+	}
+	
+	@Test
+	public void testLayoutSelfEdges()
+	{
+		Edge selfEdge = new AggregationEdge();
+		Edge nonSelfEdge = new AggregationEdge();
+		selfEdge.connect(aNodeA, aNodeA, aDiagram);
+		nonSelfEdge.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(selfEdge);
+		aDiagram.addEdge(nonSelfEdge);
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aNodeA.moveTo(new Point(20, 20));
+		aNodeB.moveTo(new Point(20, 300));
+		layoutSelfEdges(aDiagram);
+		EdgePath expectedPath = new EdgePath(new Point(100, 20), new Point(100, 0), new Point(140, 0), new Point(140, 40), new Point(120, 40));
+		assertEquals(expectedPath, getStoredEdgePath(selfEdge));
+		assertFalse(storageContains(nonSelfEdge));
+	}
+	
+	@Test
+	public void testBuildSelfEdge_topRight()
+	{
+		Node node = new ClassNode();
+		node.moveTo(new Point(20, 20));
+		Edge selfEdge = new AggregationEdge();
+		selfEdge.connect(node, node, aDiagram);
+		EdgePath expected = new EdgePath(new Point(100, 20), new Point(100, 0), new Point(140, 0), new Point(140, 40), new Point(120, 40));
+		assertEquals(expected, buildSelfEdge(selfEdge, NodeCorner.TOP_RIGHT));
+	}
+	
+	@Test
+	public void testBuildSelfEdge_topLeft()
+	{
+		Node node = new ClassNode();
+		node.moveTo(new Point(20, 20));
+		Edge selfEdge = new AggregationEdge();
+		selfEdge.connect(node, node, aDiagram);
+		EdgePath expected = new EdgePath(new Point(40, 20), new Point(40, 0), new Point(0, 0), new Point(0, 40), new Point(20, 40));
+		assertEquals(expected, buildSelfEdge(selfEdge, NodeCorner.TOP_LEFT));
+	}
+	
+	@Test
+	public void testBuildSelfEdge_bottomLeft()
+	{
+		Node node = new ClassNode();
+		node.moveTo(new Point(20, 20));
+		Edge selfEdge = new AggregationEdge();
+		selfEdge.connect(node, node, aDiagram);
+		EdgePath expected = new EdgePath(new Point(40, 80), new Point(40, 100), new Point(0, 100), new Point(0, 60), new Point(20, 60));
+		assertEquals(expected, buildSelfEdge(selfEdge, NodeCorner.BOTTOM_LEFT));
+	}
+	
+	@Test
+	public void testBuildSelfEdge_bottomRight()
+	{
+		Node node = new ClassNode();
+		node.moveTo(new Point(20, 20));
+		Edge selfEdge = new AggregationEdge();
+		selfEdge.connect(node, node, aDiagram);
+		EdgePath expected = new EdgePath(new Point(100, 80), new Point(100, 100), new Point(140, 100), new Point(140, 60), new Point(120, 60));
+		assertEquals(expected, buildSelfEdge(selfEdge, NodeCorner.BOTTOM_RIGHT));
+	}
+	
+	@Test
+	public void testGetSelfEdgeCorner()
+	{
+		Node node = new ClassNode();
+		Edge selfEdge = new AggregationEdge();
+		selfEdge.connect(node, node, aDiagram);
+		node.moveTo(new Point(100, 100));
+		aDiagram.addRootNode(node);
+		aDiagram.addEdge(selfEdge);
+		aEdgeA.connect(node, aNodeB, aDiagram);
+		aEdgeB.connect(aNodeB, node, aDiagram);
+		aEdgeC.connect(aNodeC, node, aDiagram);
+		aEdgeD.connect(node, aNodeD, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		aDiagram.addEdge(aEdgeB);
+		aDiagram.addEdge(aEdgeC);
+		aDiagram.addEdge(aEdgeD);
+		//Create EdgePaths which connect to each node corner:
+		//the exact EdgePaths are irrelevant, but the edgePath must start or end at one of selfEdge's connection points
+		EdgePath connectedToTopRight = new EdgePath(new Point(180, 100), new Point(180, 80), new Point(220, 80), new Point(200, 120));
+		EdgePath connectedToTopLeft =  new EdgePath(new Point(120, 100), new Point(100, 100), new Point(100, 80), new Point(80, 80));
+		EdgePath connectedToBottomLeft = new EdgePath(new Point(100, 140), new Point(80, 140), new Point(80, 100), new Point(60, 100));
+		EdgePath connectedToBottomRight = new EdgePath(new Point(180, 160), new Point(200, 160), new Point(200, 200), new Point(220, 200));
+		
+		//Start out with all nodeCorner connection points being available
+		assertEquals(NodeCorner.TOP_RIGHT, getSelfEdgeCorner(selfEdge));
+		
+		//make top-right corner unavailable: 
+		store(aEdgeA, connectedToTopRight);
+		assertEquals(NodeCorner.TOP_LEFT, getSelfEdgeCorner(selfEdge));
+		
+		//make top-left corner also unavailable:
+		store(aEdgeB, connectedToTopLeft);
+		assertEquals(NodeCorner.BOTTOM_LEFT, getSelfEdgeCorner(selfEdge));
+		
+		//make bottom-left corner unavailable:
+		store(aEdgeC, connectedToBottomLeft);
+		assertEquals(NodeCorner.BOTTOM_RIGHT, getSelfEdgeCorner(selfEdge));
+		
+		//make bottom right corner unavailable:
+		store(aEdgeD, connectedToBottomRight);
+		assertEquals(NodeCorner.TOP_RIGHT, getSelfEdgeCorner(selfEdge));
+	}
+	
+	@Test
+	public void testGetEdgesToMergeStart()
+	{
+		Node startNode = new ClassNode();
+		Node nodeA = new ClassNode();
+		Node nodeB = new ClassNode();
+		Node nodeC = new ClassNode();
+		Node nodeD = new ClassNode();
+		Node nodeE = new ClassNode();
+		Node nodeF = new ClassNode();
+		Edge edgeA = new AggregationEdge();
+		Edge edgeB = new AggregationEdge();
+		Edge edgeC = new GeneralizationEdge();
+		AggregationEdge edgeD = new AggregationEdge();
+		Edge edgeE = new AggregationEdge();
+		Edge edgeF = new AggregationEdge();
+		startNode.moveTo(new Point(200, 120));
+		//edgeA should not be in the resulting list of edges to merge (it is pEdge)
+		nodeA.moveTo(new Point(0, 0));
+		edgeA.connect(startNode, nodeA, aDiagram);
+		
+		//edgeB should merge
+		nodeB.moveTo(new Point(0, 100));
+		edgeB.connect(startNode, nodeB, aDiagram);
+		
+		//edgeC should not merge (its has a different EdgePriority)
+		nodeC.moveTo(new Point(0, 200));
+		edgeC.connect(nodeC, startNode, aDiagram);
+		store(edgeC, new EdgePath(new Point(100, 250), new Point(150, 250), new Point(150, 250), new Point(200, 250)));
+		
+		//edgeD should not merge (start label)
+		nodeD.moveTo(new Point(0, 300));
+		edgeD.connect(startNode, nodeD, aDiagram);
+		edgeD.setStartLabel("label");
+		
+		//edgeE should not merge (it is not outgoing from startNode)
+		nodeE.moveTo(new Point(0, 400));
+		edgeE.connect(nodeE, startNode, aDiagram);
+		
+		//edgeF should not connect (it has a different attachment side)
+		nodeF.moveTo(new Point(200, 210));
+		edgeF.connect(startNode, nodeF, aDiagram);
+		
+		aDiagram.addRootNode(startNode);
+		aDiagram.addRootNode(nodeA);
+		aDiagram.addRootNode(nodeB);
+		aDiagram.addRootNode(nodeC);
+		aDiagram.addRootNode(nodeD);
+		aDiagram.addRootNode(nodeE);
+		aDiagram.addRootNode(nodeF);
+		aDiagram.addEdge(edgeA);
+		aDiagram.addEdge(edgeB);
+		aDiagram.addEdge(edgeC);
+		aDiagram.addEdge(edgeD);
+		aDiagram.addEdge(edgeE);
+		aDiagram.addEdge(edgeF);
+		
+		List<Edge> edges = new ArrayList<>();
+		edges.addAll(Arrays.asList(edgeA, edgeB, edgeC, edgeD, edgeE, edgeF));
+		Collection<Edge> result = getEdgesToMergeStart(edgeA, edges);
+		assertEquals(1, result.size());
+		assertTrue(result.contains(edgeB));
+	}
+	
+	@Test
+	public void testGetEdgesToMergeEnd()
+	{
+		//Create a diagram with 6 edges incoming on endNode and determine which edges should merge with edgeD
+		Node endNode = new ClassNode();
+		Node nodeA = new ClassNode();
+		Node nodeB = new ClassNode();
+		Node nodeC = new ClassNode();
+		Node nodeD = new ClassNode();
+		Node nodeE = new ClassNode();
+		Node nodeF = new ClassNode();
+		Edge edgeA = new GeneralizationEdge(Type.Implementation);
+		Edge edgeB = new GeneralizationEdge(Type.Implementation);
+		Edge edgeC = new GeneralizationEdge(Type.Implementation);
+		Edge edgeD = new GeneralizationEdge(Type.Implementation);
+		Edge edgeE = new GeneralizationEdge(Type.Inheritance);
+		Edge edgeF = new GeneralizationEdge(Type.Implementation);
+		endNode.moveTo(new Point(250, 0));
+		//edgeA should not merge: different attachment side
+		nodeA.moveTo(new Point(0,0));
+		edgeA.connect(nodeA, endNode, aDiagram);
+		
+		//edgeB should not merge: different direction
+		nodeB.moveTo(new Point(0,180));
+		edgeB.connect(endNode, nodeB, aDiagram);
+		
+		//edgeC should merge
+		nodeC.moveTo(new Point(100,180));
+		edgeC.connect(nodeC, endNode, aDiagram);
+		
+		//edgeD is the edge to merge (so it should not be included in the resulting list)
+		nodeD.moveTo(new Point(200, 180));
+		edgeD.connect(nodeD, endNode, aDiagram);
+		
+		//edgeE should not merge: (it is a different priority type)
+		nodeE.moveTo(new Point(300, 180));
+		edgeE.connect(nodeE, endNode, aDiagram);
+		store(edgeE, new EdgePath(new Point(350, 180), new Point(350, 120), new Point(300, 120), new Point(300, 60)));
+		
+		//edgeF should not merge: it there is another edge (edgeE) in between it and edgeD
+		nodeF.moveTo(new Point(400, 180));
+		edgeF.connect(nodeF, endNode, aDiagram);
+		
+		aDiagram.addRootNode(endNode);
+		aDiagram.addRootNode(nodeA);
+		aDiagram.addRootNode(nodeB);
+		aDiagram.addRootNode(nodeC);
+		aDiagram.addRootNode(nodeD);
+		aDiagram.addRootNode(nodeE);
+		aDiagram.addRootNode(nodeF);
+		aDiagram.addEdge(edgeA);
+		aDiagram.addEdge(edgeB);
+		aDiagram.addEdge(edgeC);
+		aDiagram.addEdge(edgeD);
+		aDiagram.addEdge(edgeE);
+		aDiagram.addEdge(edgeF);
+		List<Edge> edges = new ArrayList<>();
+		edges.addAll(Arrays.asList(edgeA, edgeB, edgeC, edgeD, edgeE, edgeF));
+		Collection<Edge> result = getEdgesToMergeEnd(edgeD, edges);
+		assertEquals(1, result.size());
+		assertTrue(result.contains(edgeC));
+	}
+	
+	@Test
+	public void testStoredConflictingEdges()
+	{
+		endNode = new ClassNode();
+		for (Node node : Arrays.asList(aNodeA, aNodeB, aNodeC, aNodeD, endNode))
+		{
+			aDiagram.addRootNode(node);
+		}
+		aEdgeA = new GeneralizationEdge(Type.Implementation);
+		aEdgeB = new GeneralizationEdge(Type.Inheritance);
+		aEdgeC = new AssociationEdge();
+		aEdgeD = new DependencyEdge();
+		aEdgeA.connect(aNodeA, endNode, aDiagram);
+		aEdgeB.connect(aNodeB, endNode, aDiagram);
+		aEdgeC.connect(aNodeC, endNode, aDiagram);
+		aEdgeD.connect(aNodeD, endNode, aDiagram);
+		for (Edge edge : Arrays.asList(aEdgeA, aEdgeB, aEdgeC, aEdgeD))
+		{
+			aDiagram.addEdge(edge);
+		}
+		aNodeA.moveTo(new Point(0, 100));
+		aNodeB.moveTo(new Point(150, 100));
+		aNodeC.moveTo(new Point(270, 100));
+		aNodeD.moveTo(new Point(270, 0));
+		endNode.moveTo(new Point(100, 0));
+		
+		//aNodeA and aNodeB are South of endNode
+		//aNodeC is South-East of endNode
+		//aNodeD is East of endNode
+		//aEgdeA, aEdgeB, and aEdgeD are stored edges incoming on endNode. pEdge is aEdgeC, which is not yet in storage. 
+		store(aEdgeA, new EdgePath(new Point(50, 100), new Point(50, 80), new Point(140, 80), new Point(140, 60)));
+		store(aEdgeB, new EdgePath(new Point(200, 100), new Point(200, 80), new Point(150, 80), new Point(150, 60)));
+		store(aEdgeD, new EdgePath(new Point(270, 30), new Point(200, 30)));
+		
+		List<Edge> conflictingEdges = storedConflictingEdges(Direction.SOUTH, endNode, aEdgeC);
+		assertTrue(conflictingEdges.size() == 1);
+		assertTrue(conflictingEdges.contains(aEdgeB));
+		
+		
+	}
+	
+	@Test
+	public void testNodeIsCloserThanSegment_north()
+	{
+		//aEdgeA connects aEdgeB ---> aEdgeA
+		//aEdgeB connects aEdgeC ---> aEdgeA
+		//aEdgeC connects aEdgeD ---> aEdgeA
+		setUpThreeConnectedNodes();
+		aEdgeC.connect(aNodeD, aNodeA, aDiagram);
+		aDiagram.addRootNode(aNodeD);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(50, 120));
+		aNodeC.moveTo(new Point(150, 120));
+		aNodeD.moveTo(new Point(250, 50));
+		//aNodeB and aNodeC are South of aNodeA; aNodeD is East of aNodeA
+		store(aEdgeA, new EdgePath(new Point(100, 120), new Point(100, 90), new Point(50, 90), new Point(50, 60)));
+		assertFalse(nodeIsCloserThanSegment(aEdgeB, aNodeA, Direction.NORTH));
+		assertTrue(nodeIsCloserThanSegment(aEdgeC, aNodeA, Direction.NORTH));
+	}
+	
+	@Test
+	public void testNodeIsCloserThanSegment_south()
+	{
+		//aEdgeA connects aEdgeB ---> aEdgeA
+		//aEdgeB connects aEdgeC ---> aEdgeA
+		//aEdgeC connects aEdgeD ---> aEdgeA
+		setUpThreeConnectedNodes();
+		aEdgeC.connect(aNodeD, aNodeA, aDiagram);
+		aDiagram.addRootNode(aNodeD);
+		aNodeA.moveTo(new Point(0, 110));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeC.moveTo(new Point(200, 0));
+		aNodeD.moveTo(new Point(300, 60));
+		//aNodeB and aNodeC are North-East of aNodeA; aNodeD is North-North-East of aNodeA
+		store(aEdgeA, new EdgePath(new Point(50, 110), new Point(50, 95), new Point(150, 95), new Point(150, 60)));
+		assertFalse(nodeIsCloserThanSegment(aEdgeB, aNodeA, Direction.SOUTH));
+		assertTrue(nodeIsCloserThanSegment(aEdgeC, aNodeA, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testNodeIsCloserThanSegment_east()
+	{
+		//aEdgeA connects aEdgeB ---> aEdgeA
+		//aEdgeB connects aEdgeC ---> aEdgeA
+		//aEdgeC connects aEdgeD ---> aEdgeA
+		setUpThreeConnectedNodes();
+		aEdgeC.connect(aNodeD, aNodeA, aDiagram);
+		aDiagram.addRootNode(aNodeD);
+		aNodeA.moveTo(new Point(220, 0));
+		aNodeB.moveTo(new Point(0, 10));
+		aNodeC.moveTo(new Point(0, 70));
+		aNodeD.moveTo(new Point(60, 70));
+		//aNodeB and aNodeC are SouthWest of aNodeA; aNodeD is South-SouthWest of aNodeA
+		store(aEdgeA, new EdgePath(new Point(100, 40), new Point(160, 40), new Point(160, 30), new Point(220, 30)));
+		assertFalse(nodeIsCloserThanSegment(aEdgeB, aNodeA, Direction.EAST));
+		assertTrue(nodeIsCloserThanSegment(aEdgeC, aNodeA, Direction.EAST));
+	}
+	
+	@Test
+	public void testNodeIsCloserThanSegment_west()
+	{
+		//aEdgeA connects aEdgeB ---> aEdgeA
+		//aEdgeB connects aEdgeC ---> aEdgeA
+		//aEdgeC connects aEdgeD ---> aEdgeA
+		setUpThreeConnectedNodes();
+		aEdgeC.connect(aNodeD, aNodeA, aDiagram);
+		aDiagram.addRootNode(aNodeD);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 10));
+		aNodeC.moveTo(new Point(200, 40));
+		aNodeD.moveTo(new Point(140, 60));
+		//aNodeB and aNodeC are East of aNodeA; aNodeD is South-East of aNodeA
+		store(aEdgeA, new EdgePath(new Point(200, 40), new Point(150, 40), new Point(150, 30), new Point(100, 30)));
+		assertFalse(nodeIsCloserThanSegment(aEdgeB, aNodeA, Direction.WEST));
+		assertTrue(nodeIsCloserThanSegment(aEdgeC, aNodeA, Direction.WEST));
+	}
+	
+	
+	/*
+	 * Tests the condition where there is an edge in storage which shares the same two attached nodes as pEdge.
+	 */
+	@Test
+	public void testGetHorizontalMidline_sharedNodeEdge()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		Edge storedEdge = new GeneralizationEdge();
+		Edge newEdge = new AssociationEdge();
+		storedEdge.connect(aNodeA, aNodeB, aDiagram);
+		newEdge.connect(aNodeA, aNodeB, aDiagram);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(20, 120));
+		store(storedEdge, new EdgePath(new Point(50, 60), new Point(50, 90), new Point(70, 90), new Point(70, 120)));
+		Point newEdgeStart = new Point(60, 60);
+		Point newEdgeEnd = new Point(80, 120);
+		assertEquals(100, getHorizontalMidLine(newEdgeStart, newEdgeEnd, Direction.SOUTH, newEdge));
+	}
+	
+	
+
+	/*
+	 * Tests the condition where there are no edges in storage connected to pNode.getStart() or pNode.getEnd().
+	 * In this case, getHorizontalMidLine() can return the Y-coordinate directly in between pStart and pEnd.
+	 */
+	@Test
+	public void testGetHorizontalMidline_noSharedEdges()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(20, 120));
+		Edge newEdge = new GeneralizationEdge();
+		newEdge.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(newEdge);
+		assertEquals(90, getHorizontalMidLine(new Point(50, 60), new Point(70, 120), Direction.SOUTH, newEdge));
+	}
+	
+	@Test
+	public void testGetHorizontalMidline_storedEdgePresent()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge storedEdge = new GeneralizationEdge();
+		Edge associationEdge = new AssociationEdge();
+		Edge newAggregationEdge = new AggregationEdge();
+		storedEdge.connect(aNodeB, aNodeA, aDiagram);
+		associationEdge.connect(aNodeC, aNodeA, aDiagram);
+		newAggregationEdge.connect(aNodeC, aNodeA, aDiagram);
+		aDiagram.addEdge(newAggregationEdge);
+		aDiagram.addEdge(associationEdge);
+		//aNodeB and aNodeC are beside each other, and below aNodeA.
+		//storedEdge connects aNodeB to aNodeA
+		//newSharedStartEdge connects aNodeC to aNodeA
+		//newSharedEndEdge connects aNodeC to aNodeA
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(10, 120));
+		aNodeC.moveTo(new Point(110, 120));
+		Point startPoint = new Point(160, 120);
+		Point endPoint = new Point(50, 60);
+		//Because storedEdge is stored, the horizontal mid-segment of newEdge is shifted 10px 
+		store(storedEdge, new EdgePath(new Point(60, 120), new Point(60, 90), new Point(50, 90), new Point(50, 60)));
+		assertEquals(80, getHorizontalMidLine(startPoint, endPoint, Direction.NORTH, associationEdge));
+		assertEquals(80, getHorizontalMidLine(startPoint, endPoint, Direction.NORTH, newAggregationEdge));
+	}
+	
+	/*
+	 * Tests the condition where there is an edge in storage which shares the same two attached nodes as pEdge.
+	 */
+	@Test
+	public void getVerticalMidLine_sharedNodeEdge()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		Edge storedEdge = new GeneralizationEdge();
+		Edge newEdge = new AssociationEdge();
+		storedEdge.connect(aNodeA, aNodeB, aDiagram);
+		newEdge.connect(aNodeA, aNodeB, aDiagram);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 20));
+		store(storedEdge, new EdgePath(new Point(100, 30), new Point(150, 30), new Point(150, 50), new Point(200, 50)));
+		Point newEdgeStart = new Point(100, 40);
+		Point newEdgeEnd = new Point(200, 60);
+		assertEquals(160, getVerticalMidLine(newEdgeStart, newEdgeEnd, Direction.EAST, newEdge));
+	}
+	
+	/*
+	 * Tests the condition where there are no edges in storage connected to pNode.getStart() or pNode.getEnd().
+	 * In this case, getVerticalMidLine() can return the X-coordinate directly in between pStart and pEnd.
+	 */
+	@Test
+	public void testGetVerticalMidLine_noStoredEdges()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(20, 120));
+		Edge newEdge = new GeneralizationEdge();
+		newEdge.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(newEdge);
+		assertEquals(150, getVerticalMidLine(new Point(100, 30), new Point(200, 50), Direction.EAST, newEdge));
+	}
+	
+	@Test
+	public void testGetVerticalMidLine_storedEdgePresent()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge storedEdge = new GeneralizationEdge();
+		Edge associationEdge = new AssociationEdge();
+		Edge newAggregationEdge = new AggregationEdge();
+		storedEdge.connect(aNodeB, aNodeA, aDiagram);
+		associationEdge.connect(aNodeC, aNodeA, aDiagram);
+		newAggregationEdge.connect(aNodeC, aNodeA, aDiagram);
+		aDiagram.addEdge(newAggregationEdge);
+		aDiagram.addEdge(associationEdge);
+		//aNodeB and aNodeC are both to the left of aNodeA
+		//storedEdge connects aNodeA <--- aNodeB
+		//newSharedStartEdge connects aNodeA <--- aNodeC 
+		//newSharedEndEdge connects aNodeA <--- aNodeC 
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 10));
+		aNodeC.moveTo(new Point(200, 60));
+		assertEquals(150, getVerticalMidLine(new Point(200, 90), new Point(100, 40), Direction.WEST, associationEdge));
+		assertEquals(150, getVerticalMidLine(new Point(200, 90), new Point(100, 40), Direction.EAST, newAggregationEdge));
+		//after storedEdge is stored, the vertical mid-segment of newEdge is shifted 10px
+		store(storedEdge, new EdgePath(new Point(200, 40), new Point(150, 40), new Point(150, 30), new Point(100, 30)));
+		assertEquals(140, getVerticalMidLine(new Point(200, 90), new Point(100, 40), Direction.WEST, associationEdge));
+		assertEquals(140, getVerticalMidLine(new Point(200, 90), new Point(100, 40), Direction.WEST, newAggregationEdge));
+	}
+	
+	@Test
+	public void testHorizontalMidlineForSharedNodeEdges_aggregationAndGeneralizationEdges()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		Edge storedEdge = new GeneralizationEdge();
+		storedEdge.connect(aNodeA, aNodeB, aDiagram);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(20, 120));
+		store(storedEdge, new EdgePath(new Point(50, 60), new Point(50, 90), new Point(70, 90), new Point(70, 120)));
+		Edge associationEdgeNorth = new AssociationEdge();
+		Edge associationEdgeSouth = new AssociationEdge();
+		Edge aggregationEdgeNorth = new AggregationEdge();
+		Edge aggregationEdgeSouth = new AggregationEdge();
+		associationEdgeSouth.connect(aNodeA, aNodeB, aDiagram);
+		associationEdgeNorth.connect(aNodeB, aNodeA, aDiagram);
+		aggregationEdgeSouth.connect(aNodeA, aNodeB, aDiagram);
+		aggregationEdgeNorth.connect(aNodeB, aNodeA, aDiagram);
+		assertEquals(100, horizontalMidlineForSharedNodeEdges(storedEdge, associationEdgeSouth, Direction.SOUTH));
+		assertEquals(80, horizontalMidlineForSharedNodeEdges(storedEdge, associationEdgeNorth, Direction.NORTH));
+		assertEquals(100, horizontalMidlineForSharedNodeEdges(storedEdge, aggregationEdgeSouth, Direction.SOUTH));
+		assertEquals(80, horizontalMidlineForSharedNodeEdges(storedEdge, aggregationEdgeNorth, Direction.NORTH));
+	}
+	
+	@Test
+	public void testVerticalMidlineForSharedNodeEdges_generalizationAndAssociationEdges()
+	{
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		Edge storedEdge = new GeneralizationEdge();
+		storedEdge.connect(aNodeA, aNodeB, aDiagram);
+		//aNodeA is to the left of aNodeB
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 20));
+		store(storedEdge, new EdgePath(new Point(100, 30), new Point(150, 30), new Point(150, 50), new Point(200, 50)));
+		Edge associationEdgeEast = new AssociationEdge();
+		Edge associationEdgeWest = new AssociationEdge();
+		Edge aggregationEdgeEast = new AggregationEdge();
+		Edge aggregationEdgeWest = new AggregationEdge();
+		associationEdgeEast.connect(aNodeA, aNodeB, aDiagram);
+		associationEdgeWest.connect(aNodeB, aNodeA, aDiagram);
+		aggregationEdgeEast.connect(aNodeA, aNodeB, aDiagram);
+		aggregationEdgeWest.connect(aNodeB, aNodeA, aDiagram);
+		assertEquals(160, verticalMidlineForSharedNodeEdges(storedEdge, associationEdgeEast, Direction.EAST));
+		assertEquals(140, verticalMidlineForSharedNodeEdges(storedEdge, associationEdgeWest, Direction.WEST));
+		assertEquals(160, verticalMidlineForSharedNodeEdges(storedEdge, aggregationEdgeEast, Direction.EAST));
+		assertEquals(140, verticalMidlineForSharedNodeEdges(storedEdge, aggregationEdgeWest, Direction.WEST));
+	
+	}
+	
+
+	
+	@Test
+	public void testClosestVerticalSegment_generalizationEdge()
+	{
+		setUpThreeConnectedNodes();
+		//re-position the nodes so that aNodeA is to the left of aNodeB and aNodeC
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 10));
+		aNodeC.moveTo(new Point(200, 60));
+		//initialize a new edge which will not be in storage:
+		Node startNode = new ClassNode();
+		startNode.moveTo(new Point(200, 70));
+		Edge newEdge = new GeneralizationEdge();
+		newEdge.connect(startNode, aNodeA, aDiagram);
+		//Without any conflicting edges in storage: returns empty
+		assertEquals(Optional.empty(), closestConflictingVerticalSegment(Direction.WEST, newEdge));
+		//store the edge paths of aEdgeA and aEdgeB:
+		store(aEdgeA, new EdgePath(new Point(200, 40), new Point(150, 40), new Point(150, 30), new Point(100, 30)));
+		store(aEdgeB, new EdgePath(new Point(200, 90), new Point(140, 90), new Point(140, 40), new Point(100, 40)));
+		assertEquals(aEdgeB, closestConflictingVerticalSegment(Direction.WEST, newEdge).get());
+	}
+	
+	@Test
+	public void testClosestVerticalSegment_aggregationEdge()
+	{
+		setUpThreeConnectedNodes();
+		//re-position the nodes so that aNodeA is to the left of aNodeB and aNodeC
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 10));
+		aNodeC.moveTo(new Point(200, 60));
+		//initialize a new edge which will not be in storage:
+		Node startNode = new ClassNode();
+		startNode.moveTo(new Point(200, 70));
+		AggregationEdge newEdge = new AggregationEdge();
+		newEdge.connect(startNode, aNodeA, aDiagram);
+		//Without any conflicting edges in storage: returns empty
+		assertEquals(Optional.empty(), closestConflictingVerticalSegment(Direction.WEST, newEdge));
+		//store the edge paths of aEdgeA and aEdgeB:
+		store(aEdgeA, new EdgePath(new Point(200, 40), new Point(150, 40), new Point(150, 30), new Point(100, 30)));
+		store(aEdgeB, new EdgePath(new Point(200, 90), new Point(140, 90), new Point(140, 40), new Point(100, 40)));
+		assertEquals(aEdgeA, closestConflictingVerticalSegment(Direction.WEST, newEdge).get());
+	}
+	
+	@Test
+	public void testClosestHorizontalSegment_generalizationEdge()
+	{
+		setUpThreeConnectedNodes();
+		//Positions of nodes in this scenario: (x,y)
+			//aNodeA: 100, 140
+			//aNodeB: 110, 300
+			//aNodeC: 200, 300
+		Node startNode = new ClassNode();
+		startNode.moveTo(new Point(300, 300));
+		Edge newEdge = new GeneralizationEdge();
+		newEdge.connect(startNode, aNodeA, aDiagram);
+		assertEquals(Optional.empty(), closestConflictingHorizontalSegment(Direction.NORTH, newEdge));
+		//store the edge paths of aEdgeA and aEdgeB:
+		store(aEdgeA, new EdgePath(new Point(160, 300), new Point(160, 250), new Point(150, 250), new Point(150, 200)));
+		store(aEdgeB, new EdgePath(new Point(250, 300), new Point(250, 240), new Point(150, 240), new Point(150, 200)));
+		assertEquals(aEdgeB, closestConflictingHorizontalSegment(Direction.NORTH, newEdge).get());
+	}
+	
+	@Test
+	public void testClosestHorizontalSegment_aggregationEdge()
+	{
+		setUpThreeConnectedNodes();
+		//Positions of nodes in this scenario: (x,y)
+			//aNodeA: 100, 140
+			//aNodeB: 110, 300
+			//aNodeC: 200, 300
+		Node startNode = new ClassNode();
+		startNode.moveTo(new Point(300, 300));
+		AggregationEdge newEdge = new AggregationEdge();
+		newEdge.connect(startNode, aNodeA, aDiagram);
+		assertEquals(Optional.empty(), closestConflictingHorizontalSegment(Direction.NORTH, newEdge));
+		//store the edge paths of aEdgeA and aEdgeB:
+		store(aEdgeA, new EdgePath(new Point(160, 300), new Point(160, 250), new Point(150, 250), new Point(150, 200)));
+		store(aEdgeB, new EdgePath(new Point(250, 300), new Point(250, 240), new Point(150, 240), new Point(150, 200)));
+		assertEquals(aEdgeA, closestConflictingHorizontalSegment(Direction.NORTH, newEdge).get());
+	}
+	
+	@Test
+	public void testAdjacentHorizontalMidLine_below_generalizationEdge()
+	{
+		//aNodeA is above and to the left of aNodeB and aNodeC.
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(200,300));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeC.moveTo(new Point(0, 0));
+		//store the EdgePath of edge1:
+		store(edge1, new EdgePath(new Point(250, 300), new Point(250, 180), new Point(150, 180), new Point(150, 60)));
+		
+		//edge2 is incoming on aNodeA and its EdgeDirection is SOUTH, so it's middle segment should be 10px below pClosestStoredEdge.
+		assertEquals(190, adjacentHorizontalMidLine(edge1, edge2, Direction.SOUTH));
+		
+		//edge3 is outgoing from aNodeA and its EdgeDirection is NORTH, so it's middle segment should be 10px below pClosestStoredEdge.
+		assertEquals(190, adjacentHorizontalMidLine(edge1, edge3, Direction.NORTH));
+	}
+	
+	
+	@Test
+	public void testAdjacentHorizontalMidLine_above_generalizationEdge()
+	{
+		//aNodeA is above and to the left of aNodeB and aNodeC.
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(0,0));
+		aNodeB.moveTo(new Point(100, 200));
+		aNodeC.moveTo(new Point(200, 200));
+		//store the EdgePath of edge1:
+		store(edge1, new EdgePath(new Point(150, 200), new Point(150, 130), new Point(50, 130), new Point(50, 60)));
+		
+		//edge2 is incoming on aNodeA and its EdgeDirection is NORTH, so it's middle segment should be 10px above pClosestStoredEdge.
+		assertEquals(120, adjacentHorizontalMidLine(edge1, edge2, Direction.NORTH));
+		
+		//edge3 is outgoing from aNodeA and its EdgeDirection is SOUTH, so it's middle segment should be 10px above pClosestStoredEdge.
+		assertEquals(120, adjacentHorizontalMidLine(edge1, edge3, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testAdjacentHorizontalMidLine_below_aggregationEdge()
+	{
+		//aNodeA is above and to the left of aNodeB and aNodeC.
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new AggregationEdge();
+		Edge edge3 = new AggregationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(0,0));
+		aNodeB.moveTo(new Point(100, 200));
+		aNodeC.moveTo(new Point(200, 200));
+		//store the EdgePath of edge1:
+		store(edge1, new EdgePath(new Point(150, 200), new Point(150, 130), new Point(50, 130), new Point(50, 60)));
+		assertEquals(120, adjacentHorizontalMidLine(edge1, edge2, Direction.NORTH));
+		assertEquals(120, adjacentHorizontalMidLine(edge1, edge3, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testAdjacentHorizontalMidLine_above_aggregationEdge()
+	{
+		//aNodeA is above and to the left of aNodeB and aNodeC.
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new AggregationEdge();
+		Edge edge3 = new AggregationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(200,300));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeC.moveTo(new Point(0, 0));
+		//store the EdgePath of edge1:
+		store(edge1, new EdgePath(new Point(250, 300), new Point(250, 180), new Point(150, 180), new Point(150, 60)));
+		assertEquals(190, adjacentHorizontalMidLine(edge1, edge2, Direction.SOUTH));
+		assertEquals(190, adjacentHorizontalMidLine(edge1, edge3, Direction.NORTH));
+	}
+	
+	/*
+	 * Tests the scenario where the vertical mid-line for a GeneralizationEdge edge should be 10px to the right
+	 * of the vertical middle segment of pClosestStoredEdge.
+	 */
+	@Test
+	public void testAdjacentVerticalMidLine_right_generalizationEdge()
+	{
+		//aNodeB and aNodeC are to the left and slightly above from aNodeA. 
+		//edge1 connects aNodeB ---> aNodeA
+		//edge2 connects aNodeC ---> aNodeA
+		//edge3 connects aNodeC <--- aNodeA
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(300, 300));
+		aNodeB.moveTo(new Point(0, 100));
+		aNodeC.moveTo(new Point(0, 0));
+		//Store the path for edge1:
+		store(edge1, new EdgePath(new Point(300, 300), new Point(200, 330), new Point(200, 130), new Point(100, 130)));
+		
+		//With edge2 incoming on aNodeA: the vertical mid-line of edge2 should be 10px to the right of the vertical mid-line of edge1
+		assertEquals(210, adjacentVerticalMidLine(edge1, edge2, Direction.EAST));
+		
+		//With edge3 outgoing from aNodeA: the vertical mid-line of edge3 should be 10px to the right of the vertical mid-line of edge1
+		assertEquals(210, adjacentVerticalMidLine(edge1, edge3, Direction.WEST));
+				
+	}
+	
+	/*
+	 * Tests the situation when a GeneralizationEdge edge should have a vertical middle segment which is 10px 
+	 * to the left of the vertical middle segment of pClosestStoredEdge.
+	 */
+	@Test
+	public void testAdjacentVerticalMidLine_left_generalizationEdge()
+	{
+		//aNodeB and aNodeC are to the right and slightly above from aNodeA. 
+		//edge1 connects aNodeA <--- aNodeB
+		//edge2 connects aNodeA <--- aNodeC
+		//edge3 connects aNodeA ---> aNodeC
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(0, 400));
+		aNodeB.moveTo(new Point(300, 200));
+		aNodeC.moveTo(new Point(300, 100));
+		//Add the path of edge1 to storage
+		store(edge1, new EdgePath(new Point(100, 430), new Point(200, 430), new Point(200, 230), new Point(300, 230)));
+		
+		//With edge2 incoming on aNodeA: the vertical mid-line of edge2 should be 10px to the left of the vertical mid-line of edge1
+		assertEquals(190, adjacentVerticalMidLine(edge1, edge2, Direction.WEST));
+		
+		//With edge3 outgoing from aNodeA: the vertical mid-line of edge2 should be 10px to the left of the vertical mid-line of edge1
+		assertEquals(190, adjacentVerticalMidLine(edge1, edge3, Direction.EAST));
+	}
+	
+	/*
+	 * Tests the scenario when an AggregationEdge edge should have a vertical middle segment which is 
+	 * 10px to the right of the vertical middle segment of pClosestStoredEdge.
+	 */
+	@Test
+	public void testAdjacentVerticalMidLine_right_aggregationEdge()
+	{
+		//aNodeB and aNodeC are to the right and slightly above from aNodeA. 
+		//edge1 connects aNodeA <--- aNodeB
+		//edge2 connects aNodeA <--- aNodeC
+		//edge3 connects aNodeA ---> aNodeC
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new AggregationEdge();
+		Edge edge3 = new AggregationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(0, 400));
+		aNodeB.moveTo(new Point(300, 200));
+		aNodeC.moveTo(new Point(300, 100));
+		//Add the path of edge1 to storage
+		store(edge1, new EdgePath(new Point(100, 430), new Point(200, 430), new Point(200, 230), new Point(300, 230)));
+		assertEquals(190, adjacentVerticalMidLine(edge1, edge2, Direction.WEST));
+		assertEquals(190, adjacentVerticalMidLine(edge1, edge3, Direction.EAST));
+	}
+	
+	/*
+	 * Tests the scenario when an AggregationEdge edge should have a vertical middle segment which is 
+	 * 10px to the left of the vertical middle segment of pClosestStoredEdge.
+	 */
+	@Test
+	public void testAdjacentVerticalMidLine_left_aggregationEdge()
+	{
+		//aNodeB and aNodeC are to the left and slightly above from aNodeA. 
+		//edge1 connects aNodeB ---> aNodeA
+		//edge2 connects aNodeC ---> aNodeA
+		//edge3 connects aNodeC <--- aNodeA
+		aDiagram.addRootNode(aNodeA);
+		aDiagram.addRootNode(aNodeB);
+		aDiagram.addRootNode(aNodeC);
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new AggregationEdge();
+		Edge edge3 = new AggregationEdge();
+		edge1.connect(aNodeB, aNodeA, aDiagram);
+		edge2.connect(aNodeC, aNodeA, aDiagram);
+		edge3.connect(aNodeA, aNodeC, aDiagram);
+		aDiagram.addEdge(edge1);
+		aDiagram.addEdge(edge2);
+		aDiagram.addEdge(edge3);
+		aNodeA.moveTo(new Point(300, 300));
+		aNodeB.moveTo(new Point(0, 100));
+		aNodeC.moveTo(new Point(0, 0));
+		//Store the path for edge1:
+		store(edge1, new EdgePath(new Point(300, 300), new Point(200, 330), new Point(200, 130), new Point(100, 130)));
+		assertEquals(210, adjacentVerticalMidLine(edge1, edge2, Direction.EAST));
+		assertEquals(210, adjacentVerticalMidLine(edge1, edge3, Direction.WEST));
+	}
+	
+	
+	
+	/*
+	 * tests the getConnectionPoint() method in a scenario where edges are attached to the 
+	 * North side of their start nodes, and the South side of a common end node.
+	 * 
+	 * Note: this scenario holds when the node is unlabeled and has no methods/fields; which can change the size 
+	 * of the node and thus change the connection point coordinates. 
+	 */
+	@Test
+	public void testGetConnectionPoint_NorthSouthSides()
+	{
+		//Initialize 1 end node and 6 start nodes 
+		Node endNode = new ClassNode();
+		Node startNode1 = new ClassNode();
+		Node startNode2 = new ClassNode();
+		Node startNode3 = new ClassNode();
+		Node startNode4 = new ClassNode();
+		Node startNode5 = new ClassNode();
+		Node startNode6 = new ClassNode();
+		aDiagram.addRootNode(endNode);
+		aDiagram.addRootNode(startNode1);
+		aDiagram.addRootNode(startNode2);
+		aDiagram.addRootNode(startNode3);
+		aDiagram.addRootNode(startNode4);
+		aDiagram.addRootNode(startNode5);
+		aDiagram.addRootNode(startNode6);
+		//initialize 6 edges which start at each startNode and converge on the South side of endNode
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		Edge edge4 = new GeneralizationEdge();
+		Edge edge5 = new GeneralizationEdge();
+		Edge edge6 = new GeneralizationEdge();
+		edge1.connect(startNode1, endNode, aDiagram);
+		edge2.connect(startNode2, endNode, aDiagram);
+		edge3.connect(startNode3, endNode, aDiagram);
+		edge4.connect(startNode4, endNode, aDiagram);
+		edge5.connect(startNode5, endNode, aDiagram);
+		edge6.connect(startNode6, endNode, aDiagram);
+		//Position nodes so that all start nodes are below and to the right of endNode
+		endNode.moveTo(new Point(200, 0));
+		startNode1.moveTo(new Point(400, 300));
+		startNode2.moveTo(new Point(500, 300));
+		startNode3.moveTo(new Point(600, 300));
+		startNode4.moveTo(new Point(700, 300));
+		startNode5.moveTo(new Point(800, 300));
+		startNode6.moveTo(new Point(900, 300));
+		//edge1 should attach to index 0 on the South face of endNode
+		assertEquals(new Point(250, 60), getConnectionPoint(endNode, edge1, Direction.SOUTH));
+		store(edge1, new EdgePath(new Point(450, 300), new Point(450, 180), new Point(250, 180), new Point(250, 60)));
+		
+		//edge2 should attach to index +1 on the South face of endNode
+		assertEquals(new Point(260, 60), getConnectionPoint(endNode, edge2, Direction.SOUTH));
+		store(edge2, new EdgePath(new Point(550, 300), new Point(550, 180), new Point(260, 180), new Point(260, 60)));
+		
+		//edge3 should attach to index +2 on the South face of endNode
+		assertEquals(new Point(270, 60), getConnectionPoint(endNode, edge3, Direction.SOUTH));
+		store(edge3, new EdgePath(new Point(650, 300), new Point(650, 180), new Point(270, 180), new Point(270, 60)));
+		
+		//edge4 should attach to position +3 on the South face endNode
+		assertEquals(new Point(280, 60), getConnectionPoint(endNode, edge4, Direction.SOUTH));
+		store(edge4, new EdgePath(new Point(750, 300), new Point(750, 180), new Point(280, 180), new Point(280, 60)));
+	
+		//edge5 should attach to position +4 on the South face of endNode
+		assertEquals(new Point(290, 60), getConnectionPoint(endNode, edge5, Direction.SOUTH));
+		store(edge5, new EdgePath(new Point(850, 300), new Point(850, 180), new Point(290, 180), new Point(290, 60)));
+		
+		//when all other connection points on the side of pNode are taken, the default connection point for edge6 is position +4
+		//even if it is already occupied
+		assertEquals(new Point(290, 60), getConnectionPoint(endNode, edge6, Direction.SOUTH));
+	}
+	
+	
+	@Test
+	public void testGetConnectionPoint_EastWestSides()
+	{
+		//Initialize 1 end node and 4 start nodes 
+		Node endNode = new ClassNode();
+		Node startNode1 = new ClassNode();
+		Node startNode2 = new ClassNode();
+		Node startNode3 = new ClassNode();
+		Node startNode4 = new ClassNode();
+		aDiagram.addRootNode(endNode);
+		aDiagram.addRootNode(startNode1);
+		aDiagram.addRootNode(startNode2);
+		aDiagram.addRootNode(startNode3);
+		aDiagram.addRootNode(startNode4);
+		//initialize 4 edges which start at each startNode and converge on the West side of endNode
+		Edge edge1 = new GeneralizationEdge();
+		Edge edge2 = new GeneralizationEdge();
+		Edge edge3 = new GeneralizationEdge();
+		Edge edge4 = new GeneralizationEdge();
+		edge1.connect(startNode1, endNode, aDiagram);
+		edge2.connect(startNode2, endNode, aDiagram);
+		edge3.connect(startNode3, endNode, aDiagram);
+		edge4.connect(startNode4, endNode, aDiagram);
+		//Position nodes so that all start nodes are above and to the left of the end node
+		startNode1.moveTo(new Point(0, 0));
+		startNode2.moveTo(new Point(0, 100));
+		startNode3.moveTo(new Point(0, 200));
+		startNode4.moveTo(new Point(0, 300));
+		endNode.moveTo(new Point(300, 400));
+		
+		//edge1 should connect to position 0 on the West side of endNode
+		assertEquals(new Point(300, 430), getConnectionPoint(endNode, edge1, Direction.WEST));
+		store(edge1, new EdgePath(new Point(100, 50), new Point(200, 50), new Point(200, 430), new Point(300, 430)));
+		
+		//edge2 should connect to position -1 on the West side of endNode
+		assertEquals(new Point(300, 420), getConnectionPoint(endNode, edge2, Direction.WEST));
+		store(edge2, new EdgePath(new Point(100, 150), new Point(200, 150), new Point(200, 420), new Point(300, 420)));
+		
+		//edge3 should connect to position -2 on the West side of endNode
+		assertEquals(new Point(300, 410), getConnectionPoint(endNode, edge3, Direction.WEST));
+		store(edge3, new EdgePath(new Point(100, 250), new Point(200, 250), new Point(200, 410), new Point(300, 410)));
+		
+		//since there are no other available negative-index connection points on the West side of endNode, edge4 attaches 
+		//to position -2 on the West side of endNode by default
+		assertEquals(new Point(300, 410), getConnectionPoint(endNode, edge4, Direction.WEST));
+	}
+	
+	
+	@Test
+	public void testGetSharedNode()
+	{
+		setUpThreeConnectedNodes();
+		//Edges share a common end node:
+		assertEquals(aNodeA, getSharedNode(aEdgeA, aEdgeB));
+		assertEquals(aNodeA, getSharedNode(aEdgeB, aEdgeA));
+		//End node of aEdgeA is the start node of aEdgeB:
+		aEdgeB.connect(aNodeA, aNodeC, aDiagram);
+		assertEquals(aNodeA, getSharedNode(aEdgeA, aEdgeB));
+		assertEquals(aNodeA, getSharedNode(aEdgeB, aEdgeA));
+		//start node of aEdgeA is the start node of aEdgeB:
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		assertEquals(aNodeA, getSharedNode(aEdgeA, aEdgeB));
+		assertEquals(aNodeA, getSharedNode(aEdgeB, aEdgeA));
+	}
+	
+	
+	@Test
+	public void testNoOtherEdgesBetween_sameEdge()
+	{
+		setUpTwoConnectedNodes();
+		assertTrue(noOtherEdgesBetween(aEdgeA, aEdgeA, aNodeA));
+	}
+	
+	@Test
+	public void testNoOtherEdgesBetween_noOtherEdgesOnNodeFace()
+	{
+		setUpThreeConnectedNodes();
+		//aEdgeA and aEdgeB are the only two edges connected to the south face of aNodeA
+		assertTrue(noOtherEdgesBetween(aEdgeA, aEdgeB, aNodeA));
+	}
+	
+	@Test
+	public void testNoOtherEdgesBetween_edgeOnDifferentFace()
+	{
+		setUpThreeConnectedNodes();
+		Edge storedEdge = new GeneralizationEdge();
+		Node storedEdgeStartNode = new ClassNode();
+		storedEdge.connect(storedEdgeStartNode, aNodeA, aDiagram);
+		aDiagram.addEdge(storedEdge);
+		storedEdgeStartNode.moveTo(new Point(300, 140));
+		//Positions of nodes in this scenario: (x,y)
+		//aNodeA: 100, 140
+		//aNodeB: 110, 300
+		//aNodeC: 200, 300
+		//storedEdge: 300, 140
+		//Store storedEdgePath so it connects to the East side of aNodeA
+		store(storedEdge, new EdgePath(new Point(300, 170), new Point(250, 170), new Point(250, 170), new Point(200, 170)));
+		assertTrue(noOtherEdgesBetween(aEdgeA, aEdgeB, aNodeA));
+	}
+	
+	@Test
+	public void testNoOtherEdgesBetween_edgeOnNodeFace()
+	{
+		setUpThreeConnectedNodes();
+		Edge storedEdge = new GeneralizationEdge();
+		Node storedEdgeStartNode = new ClassNode();
+		storedEdge.connect(storedEdgeStartNode, aNodeA, aDiagram);
+		aDiagram.addEdge(storedEdge);
+		
+		//Reposition nodes so that aNodeA is above all other nodes, and storedEdgeStartNode is in between aNodeB and aNodeC: 
+		aNodeA.moveTo(new Point(400, 0));
+		aNodeB.moveTo(new Point(300, 300));
+		storedEdgeStartNode.moveTo(new Point(400, 300));
+		aNodeC.moveTo(new Point(500, 300));
+		storedEdgeStartNode.moveTo(new Point(300, 140));
+		
+		//Store storedEdgePath so it connects to the SOUTH side of aNodeA: (which is the same side that aEdgeA and aEdgeB would connect)
+		store(storedEdge, new EdgePath(new Point(450, 300), new Point(450, 180), new Point(450, 180), new Point(450, 60)));
+		assertFalse(noOtherEdgesBetween(aEdgeA, aEdgeB, aNodeA));
+		assertFalse(noOtherEdgesBetween(aEdgeB, aEdgeA, aNodeA));
+		
+		//move aNodeB so that it is beside aNodeC:
+		aNodeB.moveTo(new Point(600, 300));
+		assertTrue(noOtherEdgesBetween(aEdgeA, aEdgeB, aNodeA));
+		assertTrue(noOtherEdgesBetween(aEdgeB, aEdgeA, aNodeA));
+	}
+	
+	/*
+	 * Common node (aNodeA) is to the left of aNodeB and aNodeC.
+	 */
+	@Test
+	public void testNodesOnSameSideOfCommonNode_east()
+	
+	{
+		setUpThreeConnectedNodes();
+		aNodeA.moveTo(new Point(0, 300));
+		aNodeB.moveTo(new Point(200, 100));
+		aNodeC.moveTo(new Point(200, 200));
+		//aNodeB and aNodeC are both above and to the right of aNodeA
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.EAST));
+		
+		//Move aNodec so that it is below and to the right of aNodeA:
+		aNodeC.moveTo(new Point(200, 400));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.EAST));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeC, aNodeB, aNodeA, Direction.EAST));
+		
+		//Move aNodeB so that it is also below and to the right of aNodeA:
+		aNodeB.moveTo(new Point(200, 500));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.EAST));
+	}
+	
+	/*
+	 * Common node (aNodeA) is to the right of aNodeB and aNodeC.
+	 */
+	@Test
+	public void testNodesOnSameSideOfCommonNode_west()
+	{
+		//aNodeB and aNodeC are both to the left and above from aNode
+		setUpThreeConnectedNodes();
+		aNodeB.moveTo(new Point(0, 100));
+		aNodeC.moveTo(new Point(0, 200));
+		aNodeA.moveTo(new Point(200, 300));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.WEST));
+		
+		//move aNodeC so that it is to the left of and below aNodeA:
+		aNodeC.moveTo(new Point(0, 400));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.WEST));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeC, aNodeB, aNodeA, Direction.WEST));
+		
+		//move aNodeB so that it is also to the left of and below aNodeA:
+		aNodeB.moveTo(new Point(0, 500));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.WEST));
+		
+	}
+	
+	/*
+	 * Common node (aNodeA) is above aNodeB and aNodeC
+	 */
+	@Test
+	public void testNodesOnSameSideOfCommonNode_south()
+	{
+		setUpThreeConnectedNodes();
+		aNodeA.moveTo(new Point(300, 0));
+		aNodeB.moveTo(new Point(100, 300));
+		aNodeC.moveTo(new Point(200, 300));
+		//aNodeB and aNodeC are both below and to the left of aNodeA
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.SOUTH));
+		
+		//Move aNodeC so that it is below and to the right side of aNodeA:
+		aNodeC.moveTo(new Point(400, 300));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.SOUTH));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeC, aNodeB, aNodeA, Direction.SOUTH));
+		
+		//Move aNodeB so that it is also below and to the right of aNodeA:
+		aNodeB.moveTo(new Point(500, 300));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.SOUTH));
+	}
+	
+	/*
+	 * Common node (aNodeA) is below aNodeB and aNodeC
+	 */
+	@Test
+	public void testNodesOnSameSideOfCommonNode_north()
+	{
+		//aNodeB and aNodeC are above aNodeA and to the left
+		setUpThreeConnectedNodes();
+		aNodeC.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(100, 0));
+		aNodeA.moveTo(new Point(200, 200));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.NORTH));
+		
+		//move aNodeC so that it is above aNodeA and to the right:
+		aNodeC.moveTo(new Point(300, 0));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.NORTH));
+		assertFalse(nodesOnSameSideOfCommonNode(aNodeC, aNodeB, aNodeA, Direction.NORTH));
+		
+		//move aNodeB so it is also above aNodeA and to the right:
+		aNodeB.moveTo(new Point(400, 0));
+		assertTrue(nodesOnSameSideOfCommonNode(aNodeB, aNodeC, aNodeA, Direction.NORTH));
+	}
+	
+	@Test
+	public void testNoConflictingStartLabels_edgeTypeHasNoStartLabel()
+	{
+		//aEdgeA and aEdgeB are both generalization edges, which don't have start labels
+		assertTrue(noConflictingStartLabels(aEdgeA, aEdgeB));
+		AggregationEdge aggregationEdge = new AggregationEdge();
+		assertTrue(noConflictingStartLabels(aggregationEdge, aEdgeB));
+		assertTrue(noConflictingStartLabels(aEdgeA, aggregationEdge));
+		
+	}
+	
+	@Test
+	public void testNoConflictingStartLabels_sameStartLabels()
+	{
+		AggregationEdge aggregationEdge1 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge2 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge3 = new AggregationEdge(AggregationEdge.Type.Composition);
+		aggregationEdge1.setStartLabel("Test Label");
+		aggregationEdge2.setStartLabel("Test Label");
+		aggregationEdge3.setStartLabel("Test Label");
+		assertTrue(noConflictingStartLabels(aggregationEdge1, aggregationEdge2));
+		assertTrue(noConflictingStartLabels(aggregationEdge1, aggregationEdge3));
+	}
+	
+	@Test
+	public void testNoConflictingStartLabels_differentStartLabels()
+	{
+		AggregationEdge aggregationEdge1 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge2 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge3 = new AggregationEdge(AggregationEdge.Type.Composition);
+		aggregationEdge1.setStartLabel("Test Label");
+		aggregationEdge2.setStartLabel("Different Test Label");
+		aggregationEdge3.setStartLabel("Test Label");
+		assertFalse(noConflictingStartLabels(aggregationEdge1, aggregationEdge2));
+		assertTrue(noConflictingStartLabels(aggregationEdge1, aggregationEdge3));
+		assertTrue(noConflictingStartLabels(aggregationEdge2, aggregationEdge3));
+	}
+	
+	@Test
+	public void testNoConflictingEndLabels_edgeTypeHasNoEndLabel()
+	{
+		//aEdgeA and aEdgeB are both generalization edges, which don't have start labels
+		assertTrue(noConflictingEndLabels(aEdgeA, aEdgeB));
+		AggregationEdge aggregationEdge = new AggregationEdge();
+		assertTrue(noConflictingEndLabels(aggregationEdge, aEdgeB));
+		assertTrue(noConflictingEndLabels(aEdgeA, aggregationEdge));
+		
+	}
+	
+	@Test
+	public void testNoConflictingEndLabels_sameEndLabels()
+	{
+		AggregationEdge aggregationEdge1 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge2 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge3 = new AggregationEdge(AggregationEdge.Type.Composition);
+		aggregationEdge1.setEndLabel("Test Label");
+		aggregationEdge2.setEndLabel("Test Label");
+		aggregationEdge3.setEndLabel("Test Label");
+		assertTrue(noConflictingEndLabels(aggregationEdge1, aggregationEdge2));
+		assertTrue(noConflictingEndLabels(aggregationEdge1, aggregationEdge3));
+	}
+	
+	@Test
+	public void testNoConflictingEndLabels_differentEndLabels()
+	{
+		AggregationEdge aggregationEdge1 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge2 = new AggregationEdge(AggregationEdge.Type.Aggregation);
+		AggregationEdge aggregationEdge3 = new AggregationEdge(AggregationEdge.Type.Composition);
+		aggregationEdge1.setEndLabel("Test Label");
+		aggregationEdge2.setEndLabel("Different Test Label");
+		aggregationEdge3.setEndLabel("Test Label");
+		assertFalse(noConflictingEndLabels(aggregationEdge1, aggregationEdge2));
+		assertTrue(noConflictingEndLabels(aggregationEdge1, aggregationEdge3));
+		assertTrue(noConflictingEndLabels(aggregationEdge2, aggregationEdge3));
+	}
+	
+	@Test
+	public void testAttachedSide_aggregationEdge()
+	{
+		//aNodeB is 400px below and 400px to the right of aNodeA. 
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(400, 400));
+		//aggregationEdge connects aEdgeA to aEdgeB
+		Edge aggregationEdge = new AggregationEdge();
+		aggregationEdge.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aggregationEdge);
+		assertEquals(Direction.EAST, attachedSide(aggregationEdge, aNodeA));
+		assertEquals(Direction.WEST, attachedSide(aggregationEdge, aNodeB));	
+	}
+	
+	@Test
+	public void testAttachedSide_generalizationEdge()
+	{
+		//aNodeB is 400px below and 400px to the right of aNodeA. aEdgeA connects from aEgdeA to aEdgeB.
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(400, 400));
+		assertEquals(Direction.SOUTH, attachedSide(aEdgeA, aNodeA));
+		assertEquals(Direction.NORTH, attachedSide(aEdgeA, aNodeB));	
+	}
+	
+	@Test
+	public void testAttachedSide_storedSharedNodesEdge()
+	{
+		//aNodeB is 400px below and 400px to the right of aNodeA. aEdgeA connects from aEgdeA to aEdgeB.
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(400, 0));
+		store(aEdgeA, new EdgePath(new Point(100, 30), new Point(250, 30), new Point(250, 30), new Point(400, 30)));
+		Edge newEdge = new AggregationEdge();
+		newEdge.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(newEdge);
+		assertEquals(Direction.EAST, attachedSide(newEdge, aNodeA));
+		assertEquals(Direction.WEST, attachedSide(newEdge, aNodeB));
+			
+	}
+	
+	@Test
+	public void testAttachedSidePreferringEastWest_nodesAboveAndBelowEachOther()
+	{
+		//aNodeA is directly above aNodeB. aEdgeA connected aNodeA to aNode B. aEdgeB connects aNodeB to aNodeA.
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(0, 200));
+		aEdgeB.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aEdgeB);
+		assertEquals(Direction.SOUTH, attachedSidePreferringEastWest(aEdgeA));
+		assertEquals(Direction.NORTH, attachedSidePreferringEastWest(aEdgeB));
+	}
+	
+	
+	@Test
+	public void testAttachedSidePreferringEastWest_nodesBesideEachOther()
+	{
+		//aNodeA is directly to the left of aNodeA. The nodes are connected by aEdgeA and aEdgeB in both directions
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 0));
+		aEdgeB.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aEdgeB);
+		assertEquals(Direction.EAST, attachedSidePreferringEastWest(aEdgeA));
+		assertEquals(Direction.WEST, attachedSidePreferringEastWest(aEdgeB));
+	}
+	
+	
+	@Test
+	public void testAttachedSidePreferringNorthSouth_nodesAboveAndBelowEachother()
+	{
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(100, 200));
+		//Also connect aEdgeB from aNodeB to aNodeA to test the method for both East and West directions
+		aEdgeB.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aEdgeB);
+		assertEquals(Direction.SOUTH, attachedSidePreferringNorthSouth(aEdgeA));
+		assertEquals(Direction.NORTH, attachedSidePreferringNorthSouth(aEdgeB));
+	}
+	
+	@Test
+	public void testAttachedSidePreferringNorthSouth_nodesBesideEachOther()
+	{
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(200, 0));
+		//Also connect aEdgeB aNodeA <---- aNodeB to test the method for both East and West directions
+		aEdgeB.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aEdgeB);
+		assertEquals(Direction.EAST, attachedSidePreferringNorthSouth(aEdgeA));
+		assertEquals(Direction.WEST, attachedSidePreferringNorthSouth(aEdgeB));
+	}
+	
+	@Test
+	public void testEastWestSideUnlessNodesTooClose_nodesTooClose()
+	{
+		setUpThreeConnectedNodes();
+		//Reposition nodes so that aNodeB is to the left of aNodeA. aNodeB is also below and to the left of aNodeA,
+		//but it is closer to aNodeA than the middle segment of aEdgeA is. Thus, aEdgeB should connect from the North side of 
+		//aNodeC to the South side of aNodeA.
+		aNodeB.moveTo(new Point(100, 100));
+		aNodeC.moveTo(new Point(200, 200));
+		aNodeA.moveTo(new Point(300, 0));
+		//Store a segmented EdgePath going from pNodeB to pNode A
+		store(aEdgeA, new EdgePath(new Point(200, 150), new Point(250, 150), new Point(250, 30), new Point(300, 30)));
+		assertEquals(Direction.NORTH, eastWestSideUnlessTooClose(aEdgeB)); 
+	}
+	
+	@Test
+	public void testEastWestSideUnlessNodesTooClose_nodesNotTooClose()
+	{
+		setUpThreeConnectedNodes();
+		//Reposition nodes so that aNodeB and aNodeC are to the left of aNodeA (aNodeB is above aNodeC).
+		aNodeB.moveTo(new Point(100, 100));
+		aNodeC.moveTo(new Point(100, 200));
+		aNodeA.moveTo(new Point(300, 0));
+		//Store a segmented EdgePath going from pNodeB to pNode A
+		store(aEdgeA, new EdgePath(new Point(200, 150), new Point(250, 150), new Point(250, 30), new Point(300, 30)));
+		assertEquals(Direction.EAST, eastWestSideUnlessTooClose(aEdgeB)); 
+	}
+	
+	@Test
+	public void TestNorthSouthSideUnlessNodesTooClose_nodesNotTooClose()
+	{
+		setUpThreeConnectedNodes();
+		//store the EdgePath for aEdgeA, from aNodeB to aNodeA 
+		store(aEdgeA, new EdgePath(new Point(160, 330), new Point(160, 250), new Point(150, 250), new Point(150, 200)));
+		assertEquals(Direction.NORTH, northSouthSideUnlessTooClose(aEdgeB)); 
+	}
+	
+	@Test
+	public void testNorthSouthSideUnlessNodesTooClose_nodesTooClose()
+	{
+		setUpThreeConnectedNodes();
+		//aNodeC is closer to aNodeA than the mid-segment of aEdgeA is
+		aNodeC.moveTo(new Point(200, 210));
+		store(aEdgeA, new EdgePath(new Point(160, 330), new Point(160, 250), new Point(150, 250), new Point(150, 200)));
+		assertEquals(Direction.WEST, northSouthSideUnlessTooClose(aEdgeB)); 
+	}
+	
+	
+	@Test
+	public void testClassDiagramViewerFor()
+	{
+		Diagram diagram1 = new Diagram(DiagramType.CLASS);
+		Diagram diagram2 = new Diagram(DiagramType.CLASS);
+		aEdgeA.connect(aNodeB, aNodeA, diagram1);
+		aEdgeB.connect(new ClassNode(), new ClassNode(), diagram2);
+		diagram1.addEdge(aEdgeA);
+		diagram2.addEdge(aEdgeB);
+		assertSame(DiagramType.viewerFor(diagram1), classDiagramViewerFor(aEdgeA));
+		assertNotSame(classDiagramViewerFor(aEdgeA), classDiagramViewerFor(aEdgeB));
+	}
+	
+	@Test
+	public void testGetStoredEdgePath_edgeInStorage()
+	{
+		EdgePath path = new EdgePath(new Point(0,0), new Point(100, 100));
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		classDiagramViewerFor(aEdgeA).store(aEdgeA, path);
+		assertEquals(path, getStoredEdgePath(aEdgeA));
+	}
+	
+	@Test
+	public void testStorageContains()
+	{
+		setUpTwoConnectedNodes();
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA,  new EdgePath(new Point(130, 60), new Point(130, 130), new Point(130, 130), new Point(130, 200)));
+		assertTrue(storageContains(aEdgeA));
+	}
+	
+	@Test
+	public void testBuildSegmentedEdgePath_verticalEdgeDirection()
+	{
+		EdgePath expectedResult_north = new EdgePath(new Point(100,300), new Point(100, 150), new Point(300, 150), new Point(300, 0));
+		EdgePath expectedResult_south = new EdgePath(new Point(300,0), new Point(300, 150), new Point(100, 150), new Point(100, 300));
+		assertEquals(expectedResult_north, buildSegmentedEdgePath(Direction.NORTH, new Point(100, 300), 150, new Point(300,0)));
+		assertEquals(expectedResult_south, buildSegmentedEdgePath(Direction.SOUTH, new Point(300, 0), 150, new Point(100,300)));
+	}
+	
+	@Test
+	public void testBuildSegmentedEdgePath_horizontalEdgeDirection()
+	{
+		EdgePath expectedResult_east = new EdgePath(new Point(100,300), new Point(200, 300), new Point(200, 200), new Point(300, 200));
+		EdgePath expectedResult_west = new EdgePath(new Point(300,200), new Point(200, 200), new Point(200, 300), new Point(100, 300));
+		assertEquals(expectedResult_east, buildSegmentedEdgePath(Direction.EAST, new Point(100, 300), 200, new Point(300,200)));
+		assertEquals(expectedResult_west, buildSegmentedEdgePath(Direction.WEST, new Point(300, 200), 200, new Point(100, 300)));
+	}
+
+	@Test
+	public void testAttachedSideFromStorage_north()
+	{
+		aNodeA.moveTo(new Point(100, 0));
+		aNodeB.moveTo(new Point(100, 200));
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA, new EdgePath(new Point(130, 60), new Point(130, 130), new Point(130, 130), new Point(130, 200)));
+		assertEquals(Direction.NORTH, attachedSideFromStorage(aEdgeA, aNodeB));
+	}
+	
+	@Test
+	public void testAttachedSideFromStorage_south()
+	{
+		aNodeA.moveTo(new Point(100, 0));
+		aNodeB.moveTo(new Point(100, 200));
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA, new EdgePath(new Point(130, 60), new Point(130, 130), new Point(130, 130), new Point(130, 200)));
+		assertEquals(Direction.SOUTH, attachedSideFromStorage(aEdgeA, aNodeA));
+	}
+	
+	@Test
+	public void testAttachedSideFromStorage_east()
+	{
+		aNodeA.moveTo(new Point(300, 300));
+		aNodeB.moveTo(new Point(200, 300));
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA, new EdgePath(new Point(260, 330), new Point(280, 330), new Point(280, 330), new Point(300, 330)));
+		assertEquals(Direction.EAST, attachedSideFromStorage(aEdgeA, aNodeB));
+	}
+	
+	@Test
+	public void testAttachedSideFromStorage_west()
+	{
+		aNodeA.moveTo(new Point(300, 300));
+		aNodeB.moveTo(new Point(200, 300));
+		aEdgeA.connect(aNodeB, aNodeA, aDiagram);
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA, new EdgePath(new Point(260, 330), new Point(280, 330), new Point(280, 330), new Point(300, 330)));
+		assertEquals(Direction.WEST, attachedSideFromStorage(aEdgeA, aNodeA));
+	}
+	
+	
+	@Test
+	public void testVerticalDistanceToNode()
+	{
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(0, 400));
+		store(aEdgeA, new EdgePath(new Point(30, 60), new Point(30, 230), new Point(30, 230), new Point(30, 400)));
+		assertEquals(170, verticalDistanceToNode(aNodeB, aEdgeA, Direction.SOUTH));		
+	}
+	
+	@Test
+	public void testHorizontalDistanceToNode()
+	{
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		aNodeA.moveTo(new Point(0, 0));
+		aNodeB.moveTo(new Point(400, 10));
+		aDiagram.addEdge(aEdgeA);
+		store(aEdgeA, new EdgePath(new Point(100, 30), new Point(225, 30), new Point(225, 40), new Point(350, 40)));
+		assertEquals(175, horizontalDistanceToNode(aNodeB, aEdgeA, Direction.WEST));		
+	}
+
+	@Test
+	public void testGetIndexSign_edgeSharingBothNodes()
+	{
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(100, 100));
+		aNodeB.moveTo(new Point(70, 0));
+		aEdgeB.connect(aNodeA, aNodeB, aDiagram);
+		aDiagram.addEdge(aEdgeB);
+		//aEdgeA connects aNodeA --> aNodeB
+		//aEdgeB connects aNodeB --> aNodeA
+		store(aEdgeA, new EdgePath(new Point(100, 100), new Point(70, 0)));
+		assertSame( 1, getIndexSign(aEdgeB, aNodeA, Direction.NORTH));
+		assertSame( 1, getIndexSign(aEdgeB, aNodeB, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testGetIndexSign_edgeNotSharingBothNodes()
+	{
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(100, 100));
+		aNodeB.moveTo(new Point(70, 0));
+		aDiagram.addEdge(aEdgeA);
+		assertSame(-1, getIndexSign(aEdgeA, aNodeA, Direction.NORTH));
+	}
+	
+	@Test
+	public void testIndexSignOnNode_otherNodeAbove()
+	{
+		setUpTwoConnectedNodes();
+		//Other node directly above start node
+		aNodeA.moveTo(new Point(100, 100));
+		aNodeB.moveTo(new Point(100, 0));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.NORTH));
+		
+		//Other node above and to the left of start node
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(450, 300));
+		assertSame(-1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.NORTH));
+		
+		//Other node above and to the right of start node
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(550, 300));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.NORTH));
+		
+	}
+	
+	@Test
+	public void testIndexSignOnNode_otherNodeBelow()
+	{
+		//end node directly below start node
+		setUpTwoConnectedNodes();
+		aNodeB.moveTo(new Point(100, 100));
+		aNodeA.moveTo(new Point(100, 400));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.SOUTH));
+		
+		//End node above and to the left of start node
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(450, 600));
+		assertSame(-1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.SOUTH));
+		
+		//End node above and to the right of start node
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(550, 600));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.SOUTH));
+	}
+	
+	@Test
+	public void testIndexSignOnNode_otherNodeOnRight()
+	{
+		//end node directly to right of start node
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(100, 100));
+		aNodeB.moveTo(new Point(400, 100));
+		assertSame(indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.EAST), 1);
+		
+		//End node to the right of start node and slightly up 
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(700, 450));
+		assertSame(indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.EAST), -1);
+		
+		//End node to the right of start node and slightly down
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(700, 550));
+		assertSame(indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.EAST), 1);
+	}
+
+	
+	@Test
+	public void testIndexSignOnNode_otherNodeOnLeft()
+	{
+		//end node directly to left of start node
+		setUpTwoConnectedNodes();
+		aNodeA.moveTo(new Point(200, 200));
+		aNodeB.moveTo(new Point(100, 200));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.WEST));
+		
+		//End node to the left of start node and slightly up 
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(400, 450));
+		assertSame(-1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.WEST));
+		
+		//End node to the left of start node and slightly down
+		aNodeA.moveTo(new Point(500, 500));
+		aNodeB.moveTo(new Point(400, 550));
+		assertSame(1, indexSignOnNode(aEdgeA, aNodeA, aNodeB, Direction.WEST));
+	}
+	
+	@Test 
+	public void testGetClosestPoint_north()
+	{
+		assertEquals(new Point(200, 290), getClosestPoint(getPoints(), Direction.NORTH));
+	}
+	
+	@Test 
+	public void testGetClosestPoint_south()
+	{
+		assertEquals(new Point(200, 310), getClosestPoint(getPoints(), Direction.SOUTH));
+	}
+	
+
+	@Test 
+	public void testGetClosestPoint_east()
+	{
+		assertEquals(new Point(210, 300), getClosestPoint(getPoints(), Direction.EAST));
+	}
+	
+	@Test 
+	public void testGetClosestPoint_west()
+	{
+		assertEquals(new Point(190, 300), getClosestPoint(getPoints(), Direction.WEST));
+	}
+	
+	
+	@Test
+	public void testGetOtherNode()
+	{
+		aEdgeA.connect(aNodeB, aNodeA, aDiagram);
+		assertSame(aNodeB, getOtherNode(aEdgeA, aNodeA));
+		assertSame(aNodeA, getOtherNode(aEdgeA, aNodeB));
+	}
+	
+	@Test
+	public void testGetNodeFace_north()
+	{
+		assertEquals(new Point(200, 200), getNodeFace(aRectangleA, Direction.NORTH).getPoint1());
+		assertEquals(new Point(300, 200), getNodeFace(aRectangleA, Direction.NORTH).getPoint2());
+	}
+	
+	@Test
+	public void testGetNodeFace_south()
+	{
+		assertEquals(new Point(200, 260), getNodeFace(aRectangleA, Direction.SOUTH).getPoint1());
+		assertEquals(new Point(300, 260), getNodeFace(aRectangleA, Direction.SOUTH).getPoint2());
+	}
+	
+	@Test
+	public void testGetNodeFace_east()
+	{
+		assertEquals(new Point(300,200), getNodeFace(aRectangleA, Direction.EAST).getPoint1());
+		assertEquals(new Point(300,260), getNodeFace(aRectangleA, Direction.EAST).getPoint2());
+	}
+	
+	@Test
+	public void testGetNodeFace_west()
+	{
+		assertEquals(new Point(200, 200), getNodeFace(aRectangleA, Direction.WEST).getPoint1());
+		assertEquals(new Point(200, 260), getNodeFace(aRectangleA, Direction.WEST).getPoint2());
+	}
+	
+	@Test
+	public void testIsOutgoingEdge()
+	{
+		aEdgeA.connect(aNodeA, aNodeB, aDiagram);
+		assertTrue(isOutgoingEdge(aEdgeA, aNodeA));
+		assertFalse(isOutgoingEdge(aEdgeA, aNodeB));
+	}
+	
+	@Test
+	public void testNorthOrSouthSide()
+	{
+		assertEquals(Direction.NORTH, northOrSouthSide(aRectangleA, aRectangleB));
+		assertEquals(Direction.SOUTH, northOrSouthSide(aRectangleB, aRectangleA));
+		assertEquals(Direction.SOUTH, northOrSouthSide(aRectangleA, aRectangleA));
+	}
+	
+	@Test
+	public void testEastOrWestSide()
+	{
+		assertEquals(Direction.WEST, eastOrWestSide(aRectangleA, aRectangleC));
+		assertEquals(Direction.EAST, eastOrWestSide(aRectangleC, aRectangleA));
+		assertEquals(Direction.EAST, eastOrWestSide(aRectangleA, aRectangleA));
+	}
+	
+	
+	
+	
+	
+	
+	/// REFLECTIVE HELPER METHODS ///
+	
+	
+	private void layoutSegmentedEdges(Diagram pDiagram, EdgePriority pEdgePriority)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("layoutSegmentedEdges", Diagram.class, EdgePriority.class);
+			method.setAccessible(true);
+			method.invoke(aLayouter, pDiagram, pEdgePriority);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	
+	private void storeMergedEndEdges(Direction pDirection, List<Edge> pEdgesToMerge, Diagram pDiagram)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("storeMergedEndEdges", Direction.class, List.class, Diagram.class);
+			method.setAccessible(true);
+			method.invoke(aLayouter, pDirection, pEdgesToMerge, pDiagram);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	private void storeMergedStartEdges(Direction pDirection, List<Edge> pEdgesToMerge, Diagram pDiagram)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("storeMergedStartEdges", Direction.class, List.class, Diagram.class);
+			method.setAccessible(true);
+			method.invoke(aLayouter, pDirection, pEdgesToMerge, pDiagram);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	private void layoutDependencyEdges(Diagram pDiagram)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("layoutDependencyEdges", Diagram.class);
+			method.setAccessible(true);
+			method.invoke(aLayouter, pDiagram);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	private void layoutSelfEdges(Diagram pDiagram)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("layoutSelfEdges", Diagram.class);
+			method.setAccessible(true);
+			method.invoke(aLayouter, pDiagram);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	private EdgePath buildSelfEdge(Edge pEdge, NodeCorner pCorner)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("buildSelfEdge", Edge.class, NodeCorner.class);
+			method.setAccessible(true);
+			return (EdgePath) method.invoke(aLayouter, pEdge, pCorner);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	private NodeCorner getSelfEdgeCorner(Edge pEdge)
+	{
+		try 
+		{
+			Method method = Layouter.class.getDeclaredMethod("getSelfEdgeCorner", Edge.class);
+			method.setAccessible(true);
+			return (NodeCorner) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+
+	
+	@SuppressWarnings("unchecked")
+	private Collection<Edge> getEdgesToMergeStart(Edge pEdge, List<Edge> pEdges)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getEdgesToMergeStart", Edge.class, List.class);
+			method.setAccessible(true);
+			return (Collection<Edge>) method.invoke(aLayouter, pEdge, pEdges);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Collection<Edge> getEdgesToMergeEnd(Edge pEdge, List<Edge> pEdges)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getEdgesToMergeEnd", Edge.class, List.class);
+			method.setAccessible(true);
+			return (Collection<Edge>) method.invoke(aLayouter, pEdge, pEdges);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private List<Edge> storedConflictingEdges(Direction pNodeFace, Node pNode, Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("storedConflictingEdges", Direction.class, Node.class, Edge.class);
+			method.setAccessible(true);
+			return (List<Edge>) method.invoke(aLayouter, pNodeFace, pNode, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private boolean nodeIsCloserThanSegment(Edge pEdge, Node pNode, Direction pAttachedSide)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("nodeIsCloserThanSegment", Edge.class, Node.class, Direction.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge, pNode, pAttachedSide);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private int getHorizontalMidLine(Point pStart, Point pEnd, Direction pEdgeDirection, Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getHorizontalMidLine", Point.class, Point.class, Direction.class, Edge.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pStart, pEnd, pEdgeDirection,pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	
+	private int getVerticalMidLine(Point pStart, Point pEnd, Direction pEdgeDirection, Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getVerticalMidLine", Point.class, Point.class, Direction.class, Edge.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pStart, pEnd, pEdgeDirection, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	
+	private int horizontalMidlineForSharedNodeEdges(Edge pEdgeWithSameNodes, Edge pNewEdge, Direction pEdgeDirection)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("horizontalMidlineForSharedNodeEdges", Edge.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEdgeWithSameNodes, pNewEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	private int verticalMidlineForSharedNodeEdges(Edge pEdgeWithSameNodes, Edge pNewEdge, Direction pEdgeDirection) 
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("verticalMidlineForSharedNodeEdges", Edge.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEdgeWithSameNodes, pNewEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Optional<Edge> closestConflictingVerticalSegment(Direction pEdgeDirection,Edge pEdge) 
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("closestConflictingVerticalSegment", Direction.class, Edge.class);
+			method.setAccessible(true);
+			return (Optional<Edge>) method.invoke(aLayouter, pEdgeDirection, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Optional<Edge> closestConflictingHorizontalSegment( Direction pEdgeDirection, Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("closestConflictingHorizontalSegment", Direction.class, Edge.class);
+			method.setAccessible(true);
+			return (Optional<Edge>) method.invoke(aLayouter, pEdgeDirection, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private int adjacentHorizontalMidLine(Edge pClosestStoredEdge, Edge pEdge, Direction pEdgeDirection)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("adjacentHorizontalMidLine", Edge.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pClosestStoredEdge, pEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	private int adjacentVerticalMidLine(Edge pClosestStoredEdge, Edge pEdge, Direction pEdgeDirection)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("adjacentVerticalMidLine", Edge.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pClosestStoredEdge, pEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+
+	private Node getSharedNode(Edge pEdgeA, Edge pEdgeB)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getSharedNode", Edge.class, Edge.class);
+			method.setAccessible(true);
+			return (Node) method.invoke(aLayouter, pEdgeA, pEdgeB);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private Point getConnectionPoint(Node pNode, Edge pEdge, Direction pAttachmentSide)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getConnectionPoint", Node.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (Point) method.invoke(aLayouter, pNode, pEdge, pAttachmentSide);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static boolean noOtherEdgesBetween(Edge pEdge1, Edge pEdge2, Node pNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("noOtherEdgesBetween", Edge.class, Edge.class, Node.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge1, pEdge2, pNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private static boolean nodesOnSameSideOfCommonNode(Node pNode1, Node pNode2, Node pCommonNode, Direction pAttachedSide)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("nodesOnSameSideOfCommonNode", Node.class, Node.class, Node.class, Direction.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pNode1, pNode2, pCommonNode, pAttachedSide);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private static boolean noConflictingStartLabels(Edge pEdge1, Edge pEdge2)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("noConflictingStartLabels", Edge.class, Edge.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge1, pEdge2);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private static boolean noConflictingEndLabels(Edge pEdge1, Edge pEdge2)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("noConflictingEndLabels", Edge.class, Edge.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge1, pEdge2);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	
+	private static Direction attachedSide(Edge pEdge, Node pNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("attachedSide", Edge.class, Node.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge, pNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static Direction attachedSidePreferringEastWest(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("attachedSidePreferringEastWest", Edge.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+
+	private static Direction attachedSidePreferringNorthSouth(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("attachedSidePreferringNorthSouth", Edge.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static Direction eastWestSideUnlessTooClose(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("eastWestSideUnlessTooClose", Edge.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	
+	private static Direction northSouthSideUnlessTooClose(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("northSouthSideUnlessTooClose", Edge.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	
+	private static void store(Edge pEdge, EdgePath pEdgePath)
+	{
+		try
+		{
+			Field privateField = ClassDiagramViewer.class.getDeclaredField("aEdgeStorage");
+			privateField.setAccessible(true);
+			EdgeStorage storage = (EdgeStorage) privateField.get(classDiagramViewerFor(pEdge));
+			storage.store(pEdge, pEdgePath);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+		}
+	}
+	
+	private static ClassDiagramViewer classDiagramViewerFor(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("classDiagramViewerFor", Edge.class);
+			method.setAccessible(true);
+			return (ClassDiagramViewer) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static EdgePath getStoredEdgePath(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getStoredEdgePath", Edge.class);
+			method.setAccessible(true);
+			return (EdgePath) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static boolean storageContains(Edge pEdge)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("storageContains", Edge.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private static EdgePath buildSegmentedEdgePath(Direction pEdgeDirection, Point pStart, int pMidLine, Point pEnd)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("buildSegmentedEdgePath", Direction.class, Point.class, int.class, Point.class);
+			method.setAccessible(true);
+			return (EdgePath) method.invoke(aLayouter, pEdgeDirection, pStart, pMidLine, pEnd);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return (EdgePath) null;
+		}
+	}
+	
+	private static Direction attachedSideFromStorage(Edge pEdge, Node pNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("attachedSideFromStorage", Edge.class, Node.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pEdge, pNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return (Direction) null;
+		}
+	}
+	
+	private int verticalDistanceToNode(Node pEndNode, Edge pEdge, Direction pEdgeDirection)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("verticalDistanceToNode", Node.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEndNode, pEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	private int horizontalDistanceToNode(Node pEndNode, Edge pEdge, Direction pEdgeDirection)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("horizontalDistanceToNode", Node.class, Edge.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEndNode, pEdge, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	private static int getIndexSign(Edge pEdge, Node pNode, Direction pSideOfNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getIndexSign", Edge.class, Node.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEdge, pNode, pSideOfNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	private static int indexSignOnNode(Edge pEdge, Node pNode, Node pOtherNode, Direction pSideOfNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("indexSignOnNode", Edge.class, Node.class, Node.class, Direction.class);
+			method.setAccessible(true);
+			return (int) method.invoke(aLayouter, pEdge, pNode, pOtherNode, pSideOfNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return -1;
+		}
+	}
+	
+	
+	private List<Point> getPoints()
+	{
+		List<Point> result = new ArrayList<>();
+		result.add(new Point(190, 300));
+		result.add(new Point(200, 310));
+		result.add(new Point(210, 300));
+		result.add(new Point(200, 290));
+		return result;
+	}
+	
+	private static Point getClosestPoint(Collection<Point> pPoints, Direction pEdgeDirection) 
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getClosestPoint", Collection.class, Direction.class);
+			method.setAccessible(true);
+			return (Point) method.invoke(aLayouter, pPoints, pEdgeDirection);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static Node getOtherNode(Edge pEdge, Node pNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getOtherNode", Edge.class, Node.class);
+			method.setAccessible(true);
+			return (Node) method.invoke(aLayouter, pEdge, pNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static Line getNodeFace(Rectangle pNodeBounds, Direction pSideOfNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("getNodeFace", Rectangle.class, Direction.class);
+			method.setAccessible(true);
+			return (Line) method.invoke(aLayouter, pNodeBounds, pSideOfNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+
+	private static boolean isOutgoingEdge(Edge pEdge, Node pNode)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("isOutgoingEdge", Edge.class, Node.class);
+			method.setAccessible(true);
+			return (boolean) method.invoke(aLayouter, pEdge, pNode);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return false;
+		}
+	}
+	
+	private static Direction northOrSouthSide(Rectangle pBounds, Rectangle pOtherBounds)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("northOrSouthSide", Rectangle.class, Rectangle.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pBounds, pOtherBounds);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	private static Direction eastOrWestSide(Rectangle pBounds, Rectangle pOtherBounds)
+	{
+		try
+		{
+			Method method = Layouter.class.getDeclaredMethod("eastOrWestSide", Rectangle.class, Rectangle.class);
+			method.setAccessible(true);
+			return (Direction) method.invoke(aLayouter, pBounds, pOtherBounds);
+		}
+		catch(ReflectiveOperationException e)
+		{
+			fail();
+			return null;
+		}
+	}
+	
+	
+}

--- a/test/ca/mcgill/cs/jetuml/views/TestNodeCorner.java
+++ b/test/ca/mcgill/cs/jetuml/views/TestNodeCorner.java
@@ -1,0 +1,121 @@
+package ca.mcgill.cs.jetuml.views;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramType;
+import ca.mcgill.cs.jetuml.diagram.Node;
+import ca.mcgill.cs.jetuml.diagram.nodes.ClassNode;
+import ca.mcgill.cs.jetuml.geom.Direction;
+import ca.mcgill.cs.jetuml.geom.Point;
+import ca.mcgill.cs.jetuml.viewers.NodeCorner;
+import ca.mcgill.cs.jetuml.viewers.edges.NodeIndex;
+
+/**
+ * Tests for the enumerated type NodeCorner
+ *
+ */
+public class TestNodeCorner 
+{
+	private static final Node aNode = new ClassNode();
+	private static final Diagram aDiagram = new Diagram(DiagramType.CLASS);
+	
+	@BeforeEach
+	private void setUpNode()
+	{
+		aDiagram.addRootNode(aNode);
+	}
+	
+
+	@Test
+	public void testGetHorizontalIndex_right()
+	{
+		assertEquals(NodeCorner.getHorizontalIndex(NodeCorner.TOP_RIGHT), NodeIndex.PLUS_THREE);
+		assertEquals(NodeCorner.getHorizontalIndex(NodeCorner.BOTTOM_RIGHT), NodeIndex.PLUS_THREE);
+	}
+	
+	@Test
+	public void testGetHorizontalIndex_left()
+	{
+		assertEquals(NodeCorner.getHorizontalIndex(NodeCorner.TOP_LEFT), NodeIndex.MINUS_THREE);
+		assertEquals(NodeCorner.getHorizontalIndex(NodeCorner.BOTTOM_LEFT), NodeIndex.MINUS_THREE);
+	}
+	
+	@Test
+	public void testGetVerticalIndex_top()
+	{
+		assertEquals(NodeCorner.getVerticalIndex(NodeCorner.TOP_LEFT), NodeIndex.MINUS_ONE);
+		assertEquals(NodeCorner.getVerticalIndex(NodeCorner.TOP_RIGHT), NodeIndex.MINUS_ONE);
+	}
+	
+	@Test
+	public void testGetVerticalIndex_bottom()
+	{
+		assertEquals(NodeCorner.getVerticalIndex(NodeCorner.BOTTOM_LEFT), NodeIndex.PLUS_ONE);
+		assertEquals(NodeCorner.getVerticalIndex(NodeCorner.BOTTOM_RIGHT), NodeIndex.PLUS_ONE);
+	}
+	
+	@Test
+	public void testHorizontalSide_top()
+	{
+		assertEquals(NodeCorner.horizontalSide(NodeCorner.TOP_LEFT), Direction.NORTH);
+		assertEquals(NodeCorner.horizontalSide(NodeCorner.TOP_RIGHT), Direction.NORTH);
+	}
+	
+	@Test
+	public void testHorizontalSide_bottom()
+	{
+		assertEquals(NodeCorner.horizontalSide(NodeCorner.BOTTOM_LEFT), Direction.SOUTH);
+		assertEquals(NodeCorner.horizontalSide(NodeCorner.BOTTOM_RIGHT), Direction.SOUTH);
+	}
+	
+	@Test
+	public void testGetVerticalSide_right()
+	{
+		assertEquals(NodeCorner.verticalSide(NodeCorner.TOP_RIGHT), Direction.EAST);
+		assertEquals(NodeCorner.verticalSide(NodeCorner.BOTTOM_RIGHT), Direction.EAST);
+	}
+	
+	@Test
+	public void testGetVerticalSide_left()
+	{
+		assertEquals(NodeCorner.verticalSide(NodeCorner.TOP_LEFT), Direction.WEST);
+		assertEquals(NodeCorner.verticalSide(NodeCorner.TOP_LEFT), Direction.WEST);
+	}
+	
+	@Test
+	public void testToPoints_topRight()
+	{
+		setUpNode();
+		assertEquals(new Point(80, 0), NodeCorner.toPoints(NodeCorner.TOP_RIGHT, aNode)[0]);
+		assertEquals(new Point(100, 20), NodeCorner.toPoints(NodeCorner.TOP_RIGHT, aNode)[1]);
+	}
+	
+	@Test
+	public void testToPoints_bottomRight()
+	{
+		setUpNode();
+		assertEquals(new Point(80, 60), NodeCorner.toPoints(NodeCorner.BOTTOM_RIGHT, aNode)[0]);
+		assertEquals(new Point(100, 40), NodeCorner.toPoints(NodeCorner.BOTTOM_RIGHT, aNode)[1]);
+	}
+	
+	@Test
+	public void testToPoints_topLeft()
+	{
+		setUpNode();
+		assertEquals(new Point(20, 0), NodeCorner.toPoints(NodeCorner.TOP_LEFT, aNode)[0]);
+		assertEquals(new Point(0, 20), NodeCorner.toPoints(NodeCorner.TOP_LEFT, aNode)[1]);
+	}
+	
+	@Test
+	public void testToPoints_bottomLeft()
+	{
+		setUpNode();
+		assertEquals(new Point(20, 60), NodeCorner.toPoints(NodeCorner.BOTTOM_LEFT, aNode)[0]);
+		assertEquals(new Point(0, 40), NodeCorner.toPoints(NodeCorner.BOTTOM_LEFT, aNode)[1]);
+	}
+	
+	
+}


### PR DESCRIPTION
**In order to plan the paths of edges in class diagrams, several initial changes are needed:**
1. A way to represent the path of an edge
2. A way to store the paths of edges
3. A way to classify edges so that their paths can be planned in a predictable order

To meet these requirements 3 classes: `EdgePath`, `EdgeStorage`, and `EdgePriority` were added.

### **Representing and storing the paths of edges**
An `EdgePath` class was added, which represents the path of an edge in a class diagram as a list of `Point`s. An `EdgeStorage` class was created, which maps the edges of a class diagram to `EdgePath`s. 

Once the `Layouter` class is implemented, it will plan the `EdgePath`s of edges in a class diagram and store them in `EdgeStorage`. Then, these stored paths can be used to draw clean, readable class diagrams without edge overlapping. 

![edgestorage](https://user-images.githubusercontent.com/90351737/164767646-3dcaa10f-3b9e-4688-ac58-c83cab025f77.jpg)

The `EdgeStorage` class has several public methods, including a method which allows users to store an `Edge` and its `EdgePath`, and a method to get the stored `EdgePath` of an `Edge`. Notably, `EdgeStorage` has a `clearStorage()` method which clears all entries of edges and their `EdgePath`s. This is necessary because `EdgeStorage` must be cleared and refilled whenever the diagram changes.

### **Establishing a priority classification for edges**
An enumerated type `EdgePriority` was added which classifies class diagram edges. This way, all edges of a higher `EdgePriority` are planned before edges of lower `EdgePriority`. Classifying edges using an enumerated type is less error-prone than using the Edge class hierarchy. For example, Inheritance and Implementation edges are both considered `GeneralizationEdges`, and many different edges can be self-edges. The `EdgePriority` enumerated type has several public methods which are useful for edge
classification.

The order of EdgePriority is as follows (where Inheritance edges have the highest priority):
1. Inheritance
5. Implementation
6. Aggregation
7. Composition
8. Association
9. Dependency
10. Self-edges
11. Other (non-class diagram edges)

Tests for `EdgePath`, `EdgePriority`, and `EdgeStorage` were also added. 
