### PR TITLE
Issue375 Fix selection handle drawing for class diagrams

### DIFF
--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvas.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvas.java
@@ -26,10 +26,11 @@ import ca.mcgill.cs.jetuml.application.UserPreferences.BooleanPreferenceChangeHa
 import ca.mcgill.cs.jetuml.application.UserPreferences.IntegerPreference;
 import ca.mcgill.cs.jetuml.application.UserPreferences.IntegerPreferenceChangeHandler;
 import ca.mcgill.cs.jetuml.diagram.Diagram;
+import ca.mcgill.cs.jetuml.diagram.DiagramElement;
 import ca.mcgill.cs.jetuml.diagram.DiagramType;
 import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
-import ca.mcgill.cs.jetuml.viewers.DiagramViewer;
+import ca.mcgill.cs.jetuml.viewers.ClassDiagramViewer;
 import ca.mcgill.cs.jetuml.viewers.Grid;
 import ca.mcgill.cs.jetuml.viewers.ToolGraphics;
 import ca.mcgill.cs.jetuml.viewers.ViewerUtils;
@@ -107,10 +108,29 @@ public class DiagramCanvas extends Canvas implements SelectionObserver, BooleanP
 		}
 		DiagramType.viewerFor(aDiagram).draw(aDiagram, context);
 		aController.synchronizeSelectionModel();
-		aController.getSelectionModel().forEach( selected -> ViewerUtils.drawSelectionHandles(selected, context));
+		aController.getSelectionModel().forEach( selected -> drawSelectionHandles(selected, context));
 		aController.getSelectionModel().getRubberband().ifPresent( rubberband -> ToolGraphics.drawRubberband(context, rubberband));
 		aController.getSelectionModel().getLasso().ifPresent( lasso -> ToolGraphics.drawLasso(context, lasso));
 	}
+	
+	/**
+	 * Draws the selection handles using EdgeStorage for class diagrams, or using ViewerUtils otherwise.
+	 * @param pSelected the DiagramElement selected
+	 * @param pGraphics the graphics context
+	 */
+	private void drawSelectionHandles(DiagramElement pSelected, GraphicsContext pGraphics)
+	{
+		if (getDiagram().getType() == DiagramType.CLASS)
+		{
+			ClassDiagramViewer viewer = (ClassDiagramViewer) DiagramType.viewerFor(aDiagram);
+			viewer.drawSelectionHandles(pSelected, pGraphics);
+		}
+		else
+		{
+			ViewerUtils.drawSelectionHandles(pSelected, pGraphics);
+		}
+	}
+
 	
 	@Override
 	public void selectionModelChanged()

--- a/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
+++ b/src/ca/mcgill/cs/jetuml/gui/DiagramCanvasController.java
@@ -46,7 +46,6 @@ import ca.mcgill.cs.jetuml.geom.Dimension;
 import ca.mcgill.cs.jetuml.geom.Line;
 import ca.mcgill.cs.jetuml.geom.Point;
 import ca.mcgill.cs.jetuml.geom.Rectangle;
-import ca.mcgill.cs.jetuml.viewers.DiagramViewer;
 import ca.mcgill.cs.jetuml.viewers.Grid;
 import ca.mcgill.cs.jetuml.viewers.nodes.NodeViewerRegistry;
 import javafx.scene.input.MouseEvent;

--- a/test/ca/mcgill/cs/jetuml/geom/TestEdgePath.java
+++ b/test/ca/mcgill/cs/jetuml/geom/TestEdgePath.java
@@ -55,7 +55,6 @@ public class TestEdgePath
 		assertTrue(samePath.equals(aEdgePath));
 		assertFalse(reversePath.equals(aEdgePath));
 		assertFalse(samePath.equals(nullEdgePath));
-		assertFalse(samePath.equals(new Point(0, 0)));
 		assertFalse(samePath.equals(new EdgePath(pointA, pointB, new Point(200, 200))));
 	}
 	


### PR DESCRIPTION
Fix the draw selection handles control flow for class diagrams so that the selection handles for stored edges are drawn using their stored connection points. 

![image](https://user-images.githubusercontent.com/90351737/166314994-0602ae82-c4f6-4d8a-98fe-fe5d25ebeed3.png)

Remove unused/duplicate imports