### PR TITLE
Add note about OS package managers

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,14 @@ Where `PATH_TO_JAVAFX_LIB` is the full path to the `lib` directory of the `javaf
 javaw --module-path "C:\local\Java\javafx-sdk-17.0.2\lib" --add-modules=javafx.controls,javafx.swing,java.desktop,java.prefs -jar JetUML-3.4.jar
 ```
 
+## Package Managers
+
+Some systems may have a pre-packaged version of JetUML available.
+
+| System | Link | Maintainers |
+|--------|------|-------------|
+| Arch   | [aur.archlinux.org/packages/jetuml](https://aur.archlinux.org/packages/jetuml) | Community   |
+
 ## Legacy
 
 Versions prior to 2.0 will run as a self-executing jar on any version of Java. Versions 2.0 and higher require JavaFX. They will run as a self-executing jar on Java 8 only. To run versions 2.0-2.6 on Java 11 and later, follow the instructions for [thin jar](#thin-jar), above.


### PR DESCRIPTION
If your package manager has JetUML in its repos, getting the software that way may be preferable to manually downloading and updating it.

I've been maintaining a [build script](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=jetuml) for the thin jar on the [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) for two years.[^1]

It seems there was also work on getting JetUML onto flathub #433, so imo it'd be useful to list these places in the docs.

[^1]: Basically this means that users of Arch based Distros can get JetUML like any other package. On installation, a script downloads the latest jar from your GitHub releases and creates desktop shortcuts and scripts that will call Java with the correct parameters to launch the app.