### PR TITLE
Issue #478 Fix isAssignableFrom direction and throw error when list contains multiple elements

### DIFF
--- a/src/org/jetuml/gui/EditorFrame.java
+++ b/src/org/jetuml/gui/EditorFrame.java
@@ -309,7 +309,7 @@ public class EditorFrame extends BorderPane
 				alert.showAndWait();
 			}
 		}
-		catch(IOException | DeserializationException exception) 
+		catch(IOException | DeserializationException | IllegalStateException exception) 
 		{
 			Alert alert = new Alert(AlertType.ERROR, RESOURCES.getString("error.open_file"), ButtonType.OK);
 			alert.initOwner(aMainStage);

--- a/src/org/jetuml/rendering/SequenceDiagramRenderer.java
+++ b/src/org/jetuml/rendering/SequenceDiagramRenderer.java
@@ -300,13 +300,15 @@ public final class SequenceDiagramRenderer extends AbstractDiagramRenderer
 	private Optional<Node> findRoot()
 	{
 		Set<Node> calledNodes = diagram().edges().stream()
-				.filter(edge -> edge.getClass().isAssignableFrom(CallEdge.class)) // Includes subclasses, such as constructor edges
+				.filter(edge -> CallEdge.class.isAssignableFrom(edge.getClass())) // Includes subclasses, such as constructor edges
 				.map(Edge::getEnd)
 				.collect(Collectors.toSet());
 		return diagram().allNodes().stream()
 			.filter(node -> node.getClass() == CallNode.class)
 			.filter(node -> !calledNodes.contains(node))
-			.findFirst();
+			.reduce((Node a,  Node b) -> { 
+					throw new IllegalStateException("Multiple elements: " + a + ", " + b);
+			});
 	}
 	
 	public int getCenterXCoordinate(ImplicitParameterNode pNode)


### PR DESCRIPTION
Issue #478 Fix isAssignableFrom direction and throw error when list contains multiple elements

* In SequenceDiagramRenderer fix findRoot() method causing the intermittent bug
* In EditorFrame, catch the case when a list of possible roots contains more than one element, and display the error.open_file on gui