### PR TITLE
Fix issue #484

### DIFF
--- a/src/org/jetuml/diagram/builder/DiagramBuilder.java
+++ b/src/org/jetuml/diagram/builder/DiagramBuilder.java
@@ -480,7 +480,7 @@ public abstract class DiagramBuilder
 		{
 			return ()-> 
 			{ 
-				Rectangle parentBound = packageNodeViewer().getBounds(parent);
+				Rectangle parentBound = packageNodeRenderer().getBounds(parent);
 				pNode.detach(); 
 				parent.removeChild(pNode); 
 				parent.translate( parentBound.getX()-parent.position().getX(),  parentBound.getY()-parent.position().getY() );
@@ -493,9 +493,9 @@ public abstract class DiagramBuilder
 		};
 	}
 	
-	private PackageNodeRenderer packageNodeViewer()
+	private PackageNodeRenderer packageNodeRenderer()
 	{
-		return (PackageNodeRenderer)DiagramType.newRendererInstanceFor(aDiagramRenderer.diagram()).rendererFor(PackageNode.class);
+		return (PackageNodeRenderer)aDiagramRenderer.rendererFor(PackageNode.class);
 	}
 	
 	private Point computePosition(Dimension pDimension, Point pRequestedPosition)

--- a/src/org/jetuml/diagram/builder/SequenceDiagramBuilder.java
+++ b/src/org/jetuml/diagram/builder/SequenceDiagramBuilder.java
@@ -248,7 +248,7 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 		{
 			if( node instanceof ImplicitParameterNode && aDiagramRenderer.contains(node, pPoint) )
 			{
-				if( !(pPoint.getY() < implicitParameterNodeViewer().getTopRectangle(node).getMaxY() + CALL_NODE_YGAP) )
+				if( !(pPoint.getY() < implicitParameterRenderer().getTopRectangle(node).getMaxY() + CALL_NODE_YGAP) )
 				{
 					return Optional.of( (ImplicitParameterNode)node );
 				}
@@ -257,9 +257,9 @@ public class SequenceDiagramBuilder extends DiagramBuilder
 		return Optional.empty();
 	}
 	
-	private ImplicitParameterNodeRenderer implicitParameterNodeViewer()
+	private ImplicitParameterNodeRenderer implicitParameterRenderer()
 	{
-		return (ImplicitParameterNodeRenderer)DiagramType.newRendererInstanceFor(aDiagramRenderer.diagram()).rendererFor(ImplicitParameterNode.class);
+		return (ImplicitParameterNodeRenderer)aDiagramRenderer.rendererFor(ImplicitParameterNode.class);
 	}
 	
 	/**


### PR DESCRIPTION
Issue #484 Node Renderer Instance from DiagramRenderer instance
* In SequenceDiagramRenderer use the existing instance to create an ImplicitParameterNode instance
* In DiagramBuilder use the existing instance to create a PackageNodeRenderer instance