### PR TITLE
[#512] Underlining Feature for Static Attributes and Methods in Class Diagrams

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,11 +4,6 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="src" path="icons"/>
 	<classpathentry kind="src" path="tipdata"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk-17.0.2">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -19,5 +14,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin/jetuml"/>
 </classpath>

--- a/src/org/jetuml/rendering/FontMetrics.java
+++ b/src/org/jetuml/rendering/FontMetrics.java
@@ -83,4 +83,19 @@ public class FontMetrics
 		double leading = aTextNode.getLayoutBounds().getMaxY();
 		return new Dimension((int) Math.round(bounds.getWidth()), (int) Math.round(bounds.getHeight() - leading));
 	}
+	
+	/**
+	 * Returns the height of a string including the leading space.
+	 * 
+	 * @param pString The string. 
+	 * @return The height of the string.
+	 * @pre pString != null
+	 */
+	public static int getHeight(String pString)
+	{
+		assert pString != null;
+		
+		Text text = new Text(pString);
+		return (int) Math.round(text.getLayoutBounds().getHeight());
+	}
 } 

--- a/src/org/jetuml/rendering/FontMetrics.java
+++ b/src/org/jetuml/rendering/FontMetrics.java
@@ -91,11 +91,11 @@ public class FontMetrics
 	 * @return The height of the string.
 	 * @pre pString != null
 	 */
-	public static int getHeight(String pString)
+	public int getHeight(String pString)
 	{
 		assert pString != null;
 		
-		Text text = new Text(pString);
-		return (int) Math.round(text.getLayoutBounds().getHeight());
+		aTextNode.setText(pString);
+		return (int) Math.round(aTextNode.getLayoutBounds().getHeight());
 	}
 } 

--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -228,13 +228,12 @@ public final class StringRenderer
 	{
 		final VPos oldVPos = pGraphics.getTextBaseline();
 		final TextAlignment oldAlign = pGraphics.getTextAlign();
+		int textX = 0;
+		int textY = 0;
 		
 		pGraphics.setTextAlign(getTextAlignment());
 		pGraphics.setTextBaseline(getTextBaseline());
 		
-		
-		int textX = 0;
-		int textY = 0;
 		if( aAlign.isHorizontallyCentered() ) 
 		{
 			textX = pRectangle.getWidth()/2;
@@ -266,7 +265,10 @@ public final class StringRenderer
 			{
 				xOffset = dimension.width();
 			}
-			
+			else if( aAlign.isTop() )
+			{
+				yOffset = dimension.height() + 1;
+			}
 			RenderingUtils.drawLine(pGraphics, textX-xOffset, textY+yOffset, 
 					textX-xOffset+dimension.width(), textY+yOffset, LineStyle.SOLID);
 		}

--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -157,6 +157,20 @@ public final class StringRenderer
 		return new Dimension(Math.round(dimension.width() + aHorizontalPadding*2), 
 				Math.round(dimension.height() + aVerticalPadding*2));
 	}
+	
+	/**
+	 * Gets the height of a string including the leading space.
+	 * 
+	 * @param pString The string.
+	 * @return The height of the string.
+	 * @pre pString != null
+	 */
+	public int getHeight(String pString)
+	{
+		assert pString != null;
+		
+		return CANVAS_FONT.getHeight(pString, aBold);
+	}
 
 	/**
 	 * Breaks up a string such that each multi-word line has at most
@@ -321,6 +335,18 @@ public final class StringRenderer
 		public Dimension getDimension(String pString, boolean pBold)
 		{
 			return getFontMetrics(pBold).getDimension(pString);
+		}
+		
+		/**
+		 * Returns the height of a string including the leading space.
+		 * 
+		 * @param pString The string.
+		 * @param pBold Whether the text is in bold.
+		 * @return The height of the string.
+		 */
+		public int getHeight(String pString, boolean pBold)
+		{
+			return getFontMetrics(pBold).getHeight(pString);
 		}
 
 		/**

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -99,12 +99,12 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 		}
 	}
 	
-	// Draws the attributes in the attribute box line by line. Attributes with the underline markup are underlined.
 	private static void drawAttribute(TypeNode pNode, Rectangle pBounds, int pSplitY, int pAttributeBoxHeight, GraphicsContext pGraphics)
 	{
 		String attributes = pNode.getAttributes();
 		String[] attributesByLine = attributes.split("\n");
 		int lineSpacing = 0;
+		
 		for( String attribute : attributesByLine )
 		{
 			if( attribute.length() > 2 && attribute.startsWith("_") && attribute.endsWith("_") )
@@ -124,12 +124,12 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 		}	
 	}
 	
-	// Draws the methods in the method box line by line. Methods with the underline markup are underlined.
 	private static void drawMethod(TypeNode pNode, Rectangle pBounds, int pSplitY, int pMethodBoxHeight, GraphicsContext pGraphics)
 	{
 		String methods = pNode.getMethods();
 		String[] methodsByLine = methods.split("\n");
 		int lineSpacing = 0;
+		
 		for( String method : methodsByLine )
 		{
 			if( method.length() > 2 && method.startsWith("_") && method.endsWith("_") )

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -28,6 +28,7 @@ import org.jetuml.diagram.nodes.TypeNode;
 import org.jetuml.geom.Dimension;
 import org.jetuml.geom.Rectangle;
 import org.jetuml.rendering.DiagramRenderer;
+import org.jetuml.rendering.FontMetrics;
 import org.jetuml.rendering.LineStyle;
 import org.jetuml.rendering.RenderingUtils;
 import org.jetuml.rendering.StringRenderer;
@@ -49,7 +50,8 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 	protected static final int TOP_INCREMENT = 20;
 	private static final StringRenderer NAME_VIEWER = StringRenderer.get(Alignment.CENTER_CENTER, TextDecoration.BOLD, TextDecoration.PADDED);
 	private static final StringRenderer STRING_VIEWER = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
-	
+	private static final StringRenderer UNDERLINING_STRING_VIEWER = StringRenderer.get(
+			Alignment.TOP_LEFT, TextDecoration.PADDED, TextDecoration.UNDERLINED);
 	/**
 	 * @param pParent The renderer for the parent diagram.
 	 */
@@ -81,20 +83,69 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 		{
 			final int splitY = bounds.getY() + nameHeight;
 			RenderingUtils.drawLine(pGraphics, bounds.getX(), splitY, bounds.getMaxX(), splitY, LineStyle.SOLID);
-			STRING_VIEWER.draw(node.getAttributes(), pGraphics, new Rectangle(bounds.getX(), splitY, bounds.getWidth(), attributeHeight));
+			drawAttribute(node, bounds, splitY, attributeHeight, pGraphics);
 			if( methodHeight > 0 )
 			{
 				final int splitY2 = splitY + attributeHeight;
 				RenderingUtils.drawLine(pGraphics, bounds.getX(), splitY2, bounds.getMaxX(), splitY2, LineStyle.SOLID);
-				STRING_VIEWER.draw(node.getMethods(), pGraphics, 
-						new Rectangle(bounds.getX(), splitY2, bounds.getWidth(), methodHeight));
+				drawMethod(node, bounds, splitY2, methodHeight, pGraphics);
 			}
 		}
 		else if( methodHeight > 0 )
 		{
 			final int splitY = bounds.getY() + nameHeight;
 			RenderingUtils.drawLine(pGraphics, bounds.getX(), splitY, bounds.getMaxX(), splitY, LineStyle.SOLID);
-			STRING_VIEWER.draw(node.getMethods(), pGraphics, new Rectangle(bounds.getX(), splitY, bounds.getWidth(), methodHeight));
+			drawMethod(node, bounds, splitY, methodHeight, pGraphics);
+		}
+	}
+	
+	// Draws the attributes in the attribute box line by line. Attributes with the underline markup are underlined.
+	private static void drawAttribute(TypeNode pNode, Rectangle pBounds, int pSplitY, int pAttributeBoxHeight, GraphicsContext pGraphics)
+	{
+		String attributes = pNode.getAttributes();
+		String[] attributesByLine = attributes.split("\n");
+		int lineSpacing = 0;
+		for( String attribute : attributesByLine )
+		{
+			if( attribute.length() > 2 && attribute.startsWith("_") && attribute.endsWith("_") )
+			{
+				StringBuilder underline = new StringBuilder(attribute);
+				underline.deleteCharAt(0);
+				underline.deleteCharAt(underline.length() - 1);
+				UNDERLINING_STRING_VIEWER.draw(underline.toString(), pGraphics, 
+						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pAttributeBoxHeight));
+			}
+			else
+			{
+				STRING_VIEWER.draw(attribute, pGraphics, 
+						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pAttributeBoxHeight));
+			}
+			lineSpacing += FontMetrics.getHeight(attribute);
+		}	
+	}
+	
+	// Draws the methods in the method box line by line. Methods with the underline markup are underlined.
+	private static void drawMethod(TypeNode pNode, Rectangle pBounds, int pSplitY, int pMethodBoxHeight, GraphicsContext pGraphics)
+	{
+		String methods = pNode.getMethods();
+		String[] methodsByLine = methods.split("\n");
+		int lineSpacing = 0;
+		for( String method : methodsByLine )
+		{
+			if( method.length() > 2 && method.startsWith("_") && method.endsWith("_") )
+			{
+				StringBuilder underline = new StringBuilder(method);
+				underline.deleteCharAt(0);
+				underline.deleteCharAt(underline.length() - 1);
+				UNDERLINING_STRING_VIEWER.draw(underline.toString(), pGraphics, 
+						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pMethodBoxHeight));
+			}
+			else
+			{
+				STRING_VIEWER.draw(method, pGraphics, 
+						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pMethodBoxHeight));
+			}
+			lineSpacing += FontMetrics.getHeight(method);
 		}	
 	}
 	

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -120,7 +120,7 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 				STRING_VIEWER.draw(attribute, pGraphics, 
 						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pAttributeBoxHeight));
 			}
-			lineSpacing += FontMetrics.getHeight(attribute);
+			lineSpacing += STRING_VIEWER.getHeight(attribute);
 		}	
 	}
 	
@@ -145,7 +145,7 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 				STRING_VIEWER.draw(method, pGraphics, 
 						new Rectangle(pBounds.getX(), pSplitY + lineSpacing, pBounds.getWidth(), pMethodBoxHeight));
 			}
-			lineSpacing += FontMetrics.getHeight(method);
+			lineSpacing += STRING_VIEWER.getHeight(method);
 		}	
 	}
 	

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -28,7 +28,6 @@ import org.jetuml.diagram.nodes.TypeNode;
 import org.jetuml.geom.Dimension;
 import org.jetuml.geom.Rectangle;
 import org.jetuml.rendering.DiagramRenderer;
-import org.jetuml.rendering.FontMetrics;
 import org.jetuml.rendering.LineStyle;
 import org.jetuml.rendering.RenderingUtils;
 import org.jetuml.rendering.StringRenderer;


### PR DESCRIPTION
Users can now underline their static features by surrounding them with the underscore ("_") markup.
E.g. \_getHeight(): int\_
Leading and trailing spaces result in no underlining.

Detection of markups is done in the `TypeNodeRenderer` class and drawing the underline by `StringRenderer`.
Adjustments were made in the `draw` method of `StringRenderer` class to accommodate underlining of text aligned to the top.