### PR TITLE
[#524] Taskbar Flashing Bug Fix

### DIFF
--- a/src/org/jetuml/gui/NotificationService.java
+++ b/src/org/jetuml/gui/NotificationService.java
@@ -48,6 +48,10 @@ public final class NotificationService
      */
     private Stage aMainStage;
     private final List<Notification> aNotifications = new ArrayList<>();
+    // Dead notifications are notifications that reached the end of their lifespan and should be
+    // removed. We store them in a separate list so that we can close them all at once when
+    // the window is maximized, to prevent having the JetUML taskbar window flashing. - See Issue #524
+    private final List<Notification> aDeadNotifications = new ArrayList<>();
 
     private NotificationService() {}
 
@@ -120,10 +124,15 @@ public final class NotificationService
         {
             return;
         }
+        aDeadNotifications.forEach(Notification::close);
+        aDeadNotifications.clear();
 
         aNotifications.add(pNotification);
 
-        pNotification.show(() -> aNotifications.remove(pNotification));
+        pNotification.show(() -> {
+            aNotifications.remove(pNotification);
+            aDeadNotifications.add(pNotification);
+        });
         updateNotificationPosition();
     }
 

--- a/src/org/jetuml/gui/ToastNotification.java
+++ b/src/org/jetuml/gui/ToastNotification.java
@@ -144,10 +144,7 @@ public final class ToastNotification implements Notification
 
         fadeOutTimeline.getKeyFrames().add(fadeOutKey);
         // We close the stage and execute the callback at the end of the fadeout animation
-        fadeOutTimeline.setOnFinished(actionEvent1 -> {
-            aStage.close();
-            pCleanUpCallback.run();
-        });
+        fadeOutTimeline.setOnFinished(actionEvent1 -> pCleanUpCallback.run());
 
         Timer notificationTimer = new Timer();
         TimerTask lifespan = new TimerTask()


### PR DESCRIPTION
This PR is a simple fix for the flashing bug mentioned in #524.

The use of `Stage::close` with JavaFX when the window is minimized makes it flash on the taskbar.
Therefore, notifications are not closed anymore once they reach the end of their lifespan.

They are moved to another list, `aDeadNotifications`, and all the notifications in this list are closed and removed when a new notification is spawned. I assumed that notifications are only spawned when the window is maximized (since they are all based on user actions).