### PR TITLE
StringRenderer Redesign

### DIFF
--- a/src/org/jetuml/rendering/CanvasFont.java
+++ b/src/org/jetuml/rendering/CanvasFont.java
@@ -20,7 +20,6 @@
  *******************************************************************************/
 package org.jetuml.rendering;
 
-import org.jetuml.annotations.Singleton;
 import org.jetuml.application.UserPreferences;
 import org.jetuml.application.UserPreferences.IntegerPreference;
 import org.jetuml.application.UserPreferences.IntegerPreferenceChangeHandler;
@@ -31,14 +30,11 @@ import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 
 /**
- * A singleton that is in sync with user font size setting and 
- * manages font metrics calculations.
+ * A utility class for StringRenderer that is in sync with  
+ * the user font size setting and manages font metrics calculations.
  */
-@Singleton
 public final class CanvasFont implements IntegerPreferenceChangeHandler
-{
-	private static final CanvasFont INSTANCE = new CanvasFont();
-	
+{	
 	private Font aFont;
 	private Font aFontBold;
 	private Font aFontItalic;
@@ -48,19 +44,15 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler
 	private FontMetrics aFontItalicMetrics;
 	private FontMetrics aFontBoldItalicMetrics;
 
-	private CanvasFont()
+	/**
+	 * Initializes its attributes based on the user's preferences.
+	 */
+	public CanvasFont()
 	{
 		refreshAttributes();
 		UserPreferences.instance().addIntegerPreferenceChangeHandler(this);
 	}
 	
-	/**
-	 * @return The CanvasFont singleton instance.
-	 */
-	public static CanvasFont instance()
-	{
-		return INSTANCE;
-	}
 	
 	/**
 	 * @param pBold Whether the font is bold.

--- a/src/org/jetuml/rendering/CanvasFont.java
+++ b/src/org/jetuml/rendering/CanvasFont.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * JetUML - A desktop application for fast UML diagramming.
+ *
+ * Copyright (C) 2020, 2021 by McGill University.
+ *     
+ * See: https://github.com/prmr/JetUML
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses.
+ *******************************************************************************/
+package org.jetuml.rendering;
+
+import org.jetuml.annotations.Singleton;
+import org.jetuml.application.UserPreferences;
+import org.jetuml.application.UserPreferences.IntegerPreference;
+import org.jetuml.application.UserPreferences.IntegerPreferenceChangeHandler;
+import org.jetuml.geom.Dimension;
+
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
+import javafx.scene.text.FontWeight;
+
+/**
+ * A singleton that is in sync with user font size setting and 
+ * manages font metrics calculations.
+ */
+@Singleton
+public final class CanvasFont implements IntegerPreferenceChangeHandler
+{
+	private static final CanvasFont INSTANCE = new CanvasFont();
+	
+	private Font aFont;
+	private Font aFontBold;
+	private Font aFontItalic;
+	private Font aFontBoldItalic;
+	private FontMetrics aFontMetrics;
+	private FontMetrics aFontBoldMetrics;
+	private FontMetrics aFontItalicMetrics;
+	private FontMetrics aFontBoldItalicMetrics;
+
+	private CanvasFont()
+	{
+		refreshAttributes();
+		UserPreferences.instance().addIntegerPreferenceChangeHandler(this);
+	}
+	
+	/**
+	 * @return The CanvasFont singleton instance.
+	 */
+	public static CanvasFont instance()
+	{
+		return INSTANCE;
+	}
+	
+	/**
+	 * @param pBold Whether the font is bold.
+	 * @param pItalic Whether the font is italic.
+	 * @return The font.
+	 */
+	public Font getFont(boolean pBold, boolean pItalic)
+	{
+		if( pBold && pItalic )
+		{
+			return aFontBoldItalic;
+		}
+		else if( pBold )
+		{
+			return aFontBold;
+		}
+		else if( pItalic )
+		{
+			return aFontItalic;
+		}
+		return aFont;
+	}
+
+	private FontMetrics getFontMetrics(boolean pBold, boolean pItalic)
+	{
+		if( pBold && pItalic )
+		{
+			return aFontBoldItalicMetrics;
+		}
+		else if( pBold )
+		{
+			return aFontBoldMetrics;
+		}
+		else if( pItalic )
+		{
+			return aFontItalicMetrics;
+		}
+		return aFontMetrics;
+	}
+
+	/**
+	 * Returns the dimension of a given string.
+	 * @param pString The string to which the bounds pertain.
+	 * @param pBold Whether the text is in bold.
+	 * @param pItalic Whether the text is in italic.
+	 * @return The dimension of the string.
+	 */
+	public Dimension getDimension(String pString, boolean pBold, boolean pItalic)
+	{
+		return getFontMetrics(pBold, pItalic).getDimension(pString);
+	}
+	
+	/**
+	 * Returns the height of a string including the leading space.
+	 * 
+	 * @param pString The string.
+	 * @param pBold Whether the text is in bold.
+	 * @param pItalic Whether the text is in italic.
+	 * @return The height of the string.
+	 */
+	public int getHeight(String pString, boolean pBold, boolean pItalic)
+	{
+		return getFontMetrics(pBold, pItalic).getHeight(pString);
+	}
+
+	@Override
+	public void integerPreferenceChanged(IntegerPreference pPreference) 
+	{
+		if ( pPreference == IntegerPreference.fontSize && aFont.getSize() != UserPreferences.instance().getInteger(pPreference) )
+		{
+			refreshAttributes();
+		}
+
+	}
+
+	private void refreshAttributes()
+	{
+		aFont = Font.font("System", UserPreferences.instance().getInteger(IntegerPreference.fontSize));
+		aFontBold = Font.font(aFont.getFamily(), FontWeight.BOLD, aFont.getSize());
+		aFontItalic = Font.font(aFont.getFamily(), FontPosture.ITALIC, aFont.getSize());
+		aFontBoldItalic = Font.font(aFont.getFamily(), FontWeight.BOLD, FontPosture.ITALIC, aFont.getSize());
+		aFontMetrics = new FontMetrics(aFont);
+		aFontBoldMetrics = new FontMetrics(aFontBold);
+		aFontItalicMetrics = new FontMetrics(aFontItalic);
+		aFontBoldItalicMetrics = new FontMetrics(aFontBoldItalic);
+	}
+
+}

--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -96,11 +96,11 @@ public final class StringRenderer
 	 * Various text decorations.
 	 */
 	public enum TextDecoration
-	{ BOLD, ITALICS, UNDERLINED, PADDED }
+	{ BOLD, ITALIC, UNDERLINED, PADDED }
 	
 	private Alignment aAlign = Alignment.CENTER_CENTER;
 	private final boolean aBold;
-	private final boolean aItalics;
+	private final boolean aItalic;
 	private final boolean aUnderlined;
 	private int aHorizontalPadding = DEFAULT_HORIZONTAL_TEXT_PADDING;
 	private int aVerticalPadding = DEFAULT_VERTICAL_TEXT_PADDING;
@@ -114,7 +114,7 @@ public final class StringRenderer
 		}
 		aAlign = pAlign;
 		aBold = pDecorations.contains(TextDecoration.BOLD);
-		aItalics = pDecorations.contains(TextDecoration.ITALICS);
+		aItalic = pDecorations.contains(TextDecoration.ITALIC);
 		aUnderlined = pDecorations.contains(TextDecoration.UNDERLINED);
 	}
 	
@@ -150,7 +150,7 @@ public final class StringRenderer
 		{
 			return EMPTY;
 		}
-		Dimension dimension = CANVAS_FONT.getDimension(pString, aBold, aItalics);
+		Dimension dimension = CANVAS_FONT.getDimension(pString, aBold, aItalic);
 		return new Dimension(Math.round(dimension.width() + aHorizontalPadding*2), 
 				Math.round(dimension.height() + aVerticalPadding*2));
 	}
@@ -166,7 +166,7 @@ public final class StringRenderer
 	{
 		assert pString != null;
 		
-		return CANVAS_FONT.getHeight(pString, aBold, aItalics);
+		return CANVAS_FONT.getHeight(pString, aBold, aItalic);
 	}
 
 	/**
@@ -260,13 +260,13 @@ public final class StringRenderer
 		}
 		
 		pGraphics.translate(pRectangle.getX(), pRectangle.getY());
-		RenderingUtils.drawText(pGraphics, textX, textY, pString.trim(), CANVAS_FONT.getFont(aBold, aItalics));
+		RenderingUtils.drawText(pGraphics, textX, textY, pString.trim(), CANVAS_FONT.getFont(aBold, aItalic));
 		
 		if(aUnderlined && pString.trim().length() > 0)
 		{
 			int xOffset = 0;
 			int yOffset = 0;
-			Dimension dimension = CANVAS_FONT.getDimension(pString, aBold, aItalics);
+			Dimension dimension = CANVAS_FONT.getDimension(pString, aBold, aItalic);
 			if( aAlign.isHorizontallyCentered() )
 			{
 				xOffset = dimension.width()/2;

--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -27,17 +27,11 @@ import java.util.Map;
 
 import org.jetuml.annotations.Flyweight;
 import org.jetuml.annotations.Immutable;
-import org.jetuml.application.UserPreferences;
-import org.jetuml.application.UserPreferences.IntegerPreference;
-import org.jetuml.application.UserPreferences.IntegerPreferenceChangeHandler;
 import org.jetuml.geom.Dimension;
 import org.jetuml.geom.Rectangle;
 
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.FontPosture;
 import javafx.scene.text.TextAlignment;
 
 /**
@@ -50,7 +44,7 @@ import javafx.scene.text.TextAlignment;
 @Flyweight
 public final class StringRenderer
 {
-	private static final CanvasFont CANVAS_FONT = new CanvasFont();
+	private static final CanvasFont CANVAS_FONT = CanvasFont.instance();
 	
 	private static final Dimension EMPTY = new Dimension(0, 0);
 	private static final int DEFAULT_HORIZONTAL_TEXT_PADDING = 7;
@@ -292,116 +286,5 @@ public final class StringRenderer
 		pGraphics.translate(-pRectangle.getX(), -pRectangle.getY());
 		pGraphics.setTextBaseline(oldVPos);
 		pGraphics.setTextAlign(oldAlign);
-	}
-	
-	/**
-	 * Responsible for performing more rudimentary operations involving font,
-	 * as well as being synchronized with the user's current font.
-	 */
-	private static final class CanvasFont implements IntegerPreferenceChangeHandler
-	{
-
-		private Font aFont;
-		private Font aFontBold;
-		private Font aFontItalics;
-		private Font aFontBoldItalics;
-		private FontMetrics aFontMetrics;
-		private FontMetrics aFontBoldMetrics;
-		private FontMetrics aFontItalicsMetrics;
-		private FontMetrics aFontBoldItalicsMetrics;
-
-		private CanvasFont()
-		{
-			refreshAttributes();
-			UserPreferences.instance().addIntegerPreferenceChangeHandler(this);
-		}
-
-		private Font getFont(boolean pBold, boolean pItalics)
-		{
-			if( pBold && pItalics )
-			{
-				return aFontBoldItalics;
-			}
-			else if( pBold )
-			{
-				return aFontBold;
-			}
-			else if( pItalics )
-			{
-				return aFontItalics;
-			}
-			return aFont;
-		}
-		
-		private FontMetrics getFontMetrics(boolean pBold, boolean pItalics)
-		{
-			if( pBold && pItalics )
-			{
-				return aFontBoldItalicsMetrics;
-			}
-			else if( pBold )
-			{
-				return aFontBoldMetrics;
-			}
-			else if( pItalics )
-			{
-				return aFontItalicsMetrics;
-			}
-			return aFontMetrics;
-		}
-
-		/**
-		 * Returns the dimension of a given string.
-		 * @param pString The string to which the bounds pertain.
-		 * @return The dimension of the string
-		 */
-		public Dimension getDimension(String pString, boolean pBold, boolean pItalics)
-		{
-			return getFontMetrics(pBold, pItalics).getDimension(pString);
-		}
-		
-		/**
-		 * Returns the height of a string including the leading space.
-		 * 
-		 * @param pString The string.
-		 * @param pBold Whether the text is in bold.
-		 * @return The height of the string.
-		 */
-		public int getHeight(String pString, boolean pBold, boolean pItalics)
-		{
-			return getFontMetrics(pBold, pItalics).getHeight(pString);
-		}
-
-		/**
-		 * Returns the font size the user currently specifies.
-		 * @return The font size
-		 */
-		public int fontSize()
-		{
-			return (int) Math.round(aFont.getSize());
-		}
-
-		@Override
-		public void integerPreferenceChanged(IntegerPreference pPreference) 
-		{
-			if ( pPreference == IntegerPreference.fontSize && aFont.getSize() != UserPreferences.instance().getInteger(pPreference) )
-			{
-				refreshAttributes();
-			}
-
-		}
-
-		private void refreshAttributes()
-		{
-			aFont = Font.font("System", UserPreferences.instance().getInteger(IntegerPreference.fontSize));
-			aFontBold = Font.font(aFont.getFamily(), FontWeight.BOLD, aFont.getSize());
-			aFontItalics = Font.font(aFont.getFamily(), FontPosture.ITALIC, aFont.getSize());
-			aFontBoldItalics = Font.font(aFont.getFamily(), FontWeight.BOLD, FontPosture.ITALIC, aFont.getSize());
-			aFontMetrics = new FontMetrics(aFont);
-			aFontBoldMetrics = new FontMetrics(aFontBold);
-			aFontItalicsMetrics = new FontMetrics(aFontItalics);
-			aFontBoldItalicsMetrics = new FontMetrics(aFontBoldItalics);
-		}
-
 	}
 }

--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -44,7 +44,7 @@ import javafx.scene.text.TextAlignment;
 @Flyweight
 public final class StringRenderer
 {
-	private static final CanvasFont CANVAS_FONT = CanvasFont.instance();
+	private static final CanvasFont CANVAS_FONT = new CanvasFont();
 	
 	private static final Dimension EMPTY = new Dimension(0, 0);
 	private static final int DEFAULT_HORIZONTAL_TEXT_PADDING = 7;

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -49,12 +49,12 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 	protected static final int TOP_INCREMENT = 20;
 	private static final StringRenderer NAME_VIEWER = StringRenderer.get(Alignment.CENTER_CENTER, TextDecoration.BOLD, TextDecoration.PADDED);
 	private static final StringRenderer ITALICS_NAME_VIEWER = StringRenderer.get(
-			Alignment.CENTER_CENTER, TextDecoration.BOLD, TextDecoration.ITALICS, TextDecoration.PADDED);
+			Alignment.CENTER_CENTER, TextDecoration.BOLD, TextDecoration.ITALIC, TextDecoration.PADDED);
 	private static final StringRenderer STRING_VIEWER = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.PADDED);
 	private static final StringRenderer UNDERLINING_STRING_VIEWER = StringRenderer.get(
 			Alignment.TOP_LEFT, TextDecoration.PADDED, TextDecoration.UNDERLINED);
 	private static final StringRenderer ITALICS_STRING_VIEWER = StringRenderer.get(
-			Alignment.TOP_LEFT, TextDecoration.PADDED, TextDecoration.ITALICS);
+			Alignment.TOP_LEFT, TextDecoration.PADDED, TextDecoration.ITALIC);
 	/**
 	 * @param pParent The renderer for the parent diagram.
 	 */

--- a/test/org/jetuml/rendering/TestFontMetrics.java
+++ b/test/org/jetuml/rendering/TestFontMetrics.java
@@ -34,10 +34,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javafx.scene.text.Font;
+import javafx.scene.text.Text;
 
 public class TestFontMetrics {
 
 	private static final FontMetrics aMetrics = new FontMetrics(Font.font("System", DEFAULT_FONT_SIZE));
+	private static final Font DEFAULT_FONT = Font.font("System", DEFAULT_FONT_SIZE);
 	// Ensures there is no caching of sorts when reusing the same Text object
 	@ParameterizedTest
 	@MethodSource("stringPairParameters")
@@ -63,5 +65,34 @@ public class TestFontMetrics {
 		assertEquals(new Dimension(0, osDependent(13,12,12)), aMetrics.getDimension(""));
 		assertEquals(new Dimension(osDependent(95, 92, 92), osDependent(13, 12, 12)), aMetrics.getDimension("Single-Line-String"));
 		assertEquals(new Dimension(osDependent(31, 30, 30), osDependent(45, 40, 45)), aMetrics.getDimension("Multi\nLine\nString"));
+	}
+	
+	private static int textBoxHeight(Text pText)
+	{
+		return (int) Math.round(pText.getLayoutBounds().getHeight());
+	}
+
+	@Test
+	public void testGetHeight_EmptyText()
+	{
+		Text emptyText = new Text("");
+		emptyText.setFont(DEFAULT_FONT);
+		assertEquals(textBoxHeight(emptyText), aMetrics.getHeight(""));	
+	}
+	
+	@Test 
+	public void testGetHeight_SingleLineText()
+	{
+		Text singleLineText = new Text("Single-Line-String");
+		singleLineText.setFont(DEFAULT_FONT);
+		assertEquals(textBoxHeight(singleLineText), aMetrics.getHeight("Single-Line-String"));	
+	}
+	
+	@Test 
+	public void testGetHeight_MultiLineText()
+	{
+		Text multiLineText = new Text("Multi\nLine\nString");
+		multiLineText.setFont(DEFAULT_FONT);
+		assertEquals(textBoxHeight(multiLineText), aMetrics.getHeight("Multi\nLine\nString"));	
 	}
 }

--- a/test/org/jetuml/rendering/TestFontMetrics.java
+++ b/test/org/jetuml/rendering/TestFontMetrics.java
@@ -23,41 +23,17 @@ package org.jetuml.rendering;
 import static org.jetuml.rendering.FontMetrics.DEFAULT_FONT_SIZE;
 import static org.jetuml.testutils.GeometryUtils.osDependent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
-import java.util.stream.Stream;
 
 import org.jetuml.geom.Dimension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import javafx.scene.text.Font;
-import javafx.scene.text.Text;
 
 public class TestFontMetrics {
 
-	private static final FontMetrics aMetrics = new FontMetrics(Font.font("System", DEFAULT_FONT_SIZE));
-	private static final Font DEFAULT_FONT = Font.font("System", DEFAULT_FONT_SIZE);
-	// Ensures there is no caching of sorts when reusing the same Text object
-	@ParameterizedTest
-	@MethodSource("stringPairParameters")
-	public void testStateNotPreserved(String firstString, String secondString)
-	{
-		
-		assertNotEquals(aMetrics.getDimension(firstString), aMetrics.getDimension(secondString));
-	}
-	
-	private static Stream<Arguments> stringPairParameters() {
-	    return Stream.of(
-	            Arguments.of("X", "XX"),
-	            Arguments.of("XX", "XXX"),
-	            Arguments.of("XXX", "XXXX"),
-	            Arguments.of("XXXX", "XXXXX"),
-	            Arguments.of("XXXXX", "XXXXXX")
-	    );
-	}
+	private static final Font DEFAULT_FONT = new Font("System", DEFAULT_FONT_SIZE);
+	private static final FontMetrics aMetrics = new FontMetrics(DEFAULT_FONT);
+	private static final String SINGLE_LINE_STRING = "One";
 	
 	@Test
 	public void testGetDimensions()
@@ -66,33 +42,22 @@ public class TestFontMetrics {
 		assertEquals(new Dimension(osDependent(95, 92, 92), osDependent(13, 12, 12)), aMetrics.getDimension("Single-Line-String"));
 		assertEquals(new Dimension(osDependent(31, 30, 30), osDependent(45, 40, 45)), aMetrics.getDimension("Multi\nLine\nString"));
 	}
-
-	@Test
-	public void testGetHeight_EmptyText()
+	
+	/**
+	 * Note that due to the rounding performed in getHeight, testing the height of strings 
+	 * with a certain number of lines will result in the test failing.
+	 * E.g. A string with 13 lines will fail this test.
+	 */
+	@Test 
+	public void testGetHeight_TwoLineString()
 	{
-		Text emptyText = new Text("");
-		emptyText.setFont(DEFAULT_FONT);
-		assertEquals(textBoxHeight(emptyText), aMetrics.getHeight(""));	
+		assertEquals(aMetrics.getHeight(SINGLE_LINE_STRING) * 2, aMetrics.getHeight("One\nTwo"));	
 	}
 	
 	@Test 
-	public void testGetHeight_SingleLineText()
+	public void testGetHeight_TenLineString()
 	{
-		Text singleLineText = new Text("Single-Line-String");
-		singleLineText.setFont(DEFAULT_FONT);
-		assertEquals(textBoxHeight(singleLineText), aMetrics.getHeight("Single-Line-String"));	
-	}
-	
-	@Test 
-	public void testGetHeight_MultiLineText()
-	{
-		Text multiLineText = new Text("Multi\nLine\nString");
-		multiLineText.setFont(DEFAULT_FONT);
-		assertEquals(textBoxHeight(multiLineText), aMetrics.getHeight("Multi\nLine\nString"));	
-	}
-	
-	private static int textBoxHeight(Text pText)
-	{
-		return (int) Math.round(pText.getLayoutBounds().getHeight());
+		assertEquals(aMetrics.getHeight(SINGLE_LINE_STRING) * 10, 
+				aMetrics.getHeight("One\nTwo\nThree\nFour\nFive\nSix\nSeven\nEight\nNine\nTen"));	
 	}
 }

--- a/test/org/jetuml/rendering/TestFontMetrics.java
+++ b/test/org/jetuml/rendering/TestFontMetrics.java
@@ -66,11 +66,6 @@ public class TestFontMetrics {
 		assertEquals(new Dimension(osDependent(95, 92, 92), osDependent(13, 12, 12)), aMetrics.getDimension("Single-Line-String"));
 		assertEquals(new Dimension(osDependent(31, 30, 30), osDependent(45, 40, 45)), aMetrics.getDimension("Multi\nLine\nString"));
 	}
-	
-	private static int textBoxHeight(Text pText)
-	{
-		return (int) Math.round(pText.getLayoutBounds().getHeight());
-	}
 
 	@Test
 	public void testGetHeight_EmptyText()
@@ -94,5 +89,10 @@ public class TestFontMetrics {
 		Text multiLineText = new Text("Multi\nLine\nString");
 		multiLineText.setFont(DEFAULT_FONT);
 		assertEquals(textBoxHeight(multiLineText), aMetrics.getHeight("Multi\nLine\nString"));	
+	}
+	
+	private static int textBoxHeight(Text pText)
+	{
+		return (int) Math.round(pText.getLayoutBounds().getHeight());
 	}
 }

--- a/test/org/jetuml/rendering/TestStringViewer.java
+++ b/test/org/jetuml/rendering/TestStringViewer.java
@@ -40,11 +40,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
-import javafx.scene.text.FontWeight;
-import javafx.scene.text.Text;
-
 public class TestStringViewer 
 {
 	private static int userDefinedFontSize;
@@ -69,8 +64,8 @@ public class TestStringViewer
 		topCenterPadded = StringRenderer.get(Alignment.TOP_CENTER, TextDecoration.PADDED);
 		topCenterBold = StringRenderer.get(Alignment.TOP_CENTER, TextDecoration.BOLD);
 		bottomCenterPadded = StringRenderer.get(Alignment.BOTTOM_CENTER, TextDecoration.PADDED);
-		topCenterItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.ITALICS);
-		topCenterBoldItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.BOLD, TextDecoration.ITALICS);
+		topCenterItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.ITALIC);
+		topCenterBoldItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.BOLD, TextDecoration.ITALIC);
 	}
 	
 	@AfterAll
@@ -144,7 +139,7 @@ public class TestStringViewer
 		try 
 		{
 			Field boldField = StringRenderer.class.getDeclaredField("aBold");
-			Field italicsField = StringRenderer.class.getDeclaredField("aItalics");
+			Field italicsField = StringRenderer.class.getDeclaredField("aItalic");
 			boldField.setAccessible(true);
 			italicsField.setAccessible(true);
 			

--- a/test/org/jetuml/rendering/TestStringViewer.java
+++ b/test/org/jetuml/rendering/TestStringViewer.java
@@ -36,6 +36,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.Text;
+
 public class TestStringViewer 
 {
 	private static int userDefinedFontSize;
@@ -43,6 +48,8 @@ public class TestStringViewer
 	private StringRenderer topCenterPadded;
 	private StringRenderer topCenterBold;
 	private StringRenderer bottomCenterPadded;
+	private StringRenderer topCenterItalics;
+	private StringRenderer topCenterBoldItalics;
 	
 	@BeforeAll
 	public static void setupClass()
@@ -58,6 +65,8 @@ public class TestStringViewer
 		topCenterPadded = StringRenderer.get(Alignment.TOP_CENTER, TextDecoration.PADDED);
 		topCenterBold = StringRenderer.get(Alignment.TOP_CENTER, TextDecoration.BOLD);
 		bottomCenterPadded = StringRenderer.get(Alignment.BOTTOM_CENTER, TextDecoration.PADDED);
+		topCenterItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.ITALICS);
+		topCenterBoldItalics = StringRenderer.get(Alignment.TOP_LEFT, TextDecoration.BOLD, TextDecoration.ITALICS);
 	}
 	
 	@AfterAll
@@ -119,5 +128,48 @@ public class TestStringViewer
 		assertEquals("Display\nString", StringRenderer.wrapString("Display String", 1));
 		assertEquals("A\nreally\nlong\nstring\nthat\nshould\nprobably\nbe\nwrapped", 
 				StringRenderer.wrapString("A really long string that should probably be wrapped", 1));
+	}
+	
+	@Test
+	public void testGetHeight_12ptFont()
+	{
+		Font defaultFont = Font.font("System", 12);
+		Font boldFont = Font.font("System", FontWeight.BOLD, 12);
+		Font italicFont = Font.font("System", FontPosture.ITALIC, 12);
+		Font boldItalicFont = Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, 12);
+		Text text = new Text("Display String");
+		text.setFont(defaultFont);
+		assertEquals(textBoxHeight(text), topCenter.getHeight("Display String"));
+		text.setFont(boldFont);
+		assertEquals(textBoxHeight(text), topCenterBold.getHeight("Display String"));
+		text.setFont(italicFont);
+		assertEquals(textBoxHeight(text), topCenterItalics.getHeight("Display String"));
+		text.setFont(boldItalicFont);
+		assertEquals(textBoxHeight(text), topCenterBoldItalics.getHeight("Display String"));
+	}
+	
+	@Test
+	public void testGetHeight_24ptFont()
+	{
+		UserPreferences.instance().setInteger(IntegerPreference.fontSize, 24);
+		Font defaultFont = Font.font("System", 24);
+		Font boldFont = Font.font("System", FontWeight.BOLD, 24);
+		Font italicFont = Font.font("System", FontPosture.ITALIC, 24);
+		Font boldItalicFont = Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, 24);
+		Text text = new Text("Display String");
+		text.setFont(defaultFont);
+		assertEquals(textBoxHeight(text), topCenter.getHeight("Display String"));
+		text.setFont(boldFont);
+		assertEquals(textBoxHeight(text), topCenterBold.getHeight("Display String"));
+		text.setFont(italicFont);
+		assertEquals(textBoxHeight(text), topCenterItalics.getHeight("Display String"));
+		text.setFont(boldItalicFont);
+		assertEquals(textBoxHeight(text), topCenterBoldItalics.getHeight("Display String"));
+		UserPreferences.instance().setInteger(IntegerPreference.fontSize, DEFAULT_FONT_SIZE);
+	}
+	
+	private static int textBoxHeight(Text pText)
+	{
+		return (int) Math.round(pText.getLayoutBounds().getHeight());
 	}
 }

--- a/test/org/jetuml/rendering/TestStringViewer.java
+++ b/test/org/jetuml/rendering/TestStringViewer.java
@@ -130,6 +130,9 @@ public class TestStringViewer
 				StringRenderer.wrapString("A really long string that should probably be wrapped", 1));
 	}
 	
+	/*
+	 * Test different font styles for font size 12.
+	 */
 	@Test
 	public void testGetHeight_12ptFont()
 	{
@@ -148,6 +151,9 @@ public class TestStringViewer
 		assertEquals(textBoxHeight(text), topCenterBoldItalics.getHeight("Display String"));
 	}
 	
+	/*
+	 * Test different font styles for font size 24.
+	 */
 	@Test
 	public void testGetHeight_24ptFont()
 	{


### PR DESCRIPTION
Class `StringRenderer` provides an interface for subsystems to render strings to their particular needs for different font styles and text alignments. 

The redesign cleaned up class `StringRenderer` to provide a minimal interface to work with. This involved moving the static inner class `CanvasFont` of `StringRenderer` to a class of its own.