### PR TITLE
[#512] Italicizing the Names of Abstract Classes with Stereotypes

### DIFF
--- a/src/org/jetuml/rendering/StringRenderer.java
+++ b/src/org/jetuml/rendering/StringRenderer.java
@@ -252,7 +252,7 @@ public final class StringRenderer
 		}
 		
 		pGraphics.translate(pRectangle.x(), pRectangle.y());
-		RenderingUtils.drawText(pGraphics, textX, textY, pString.trim(), CANVAS_FONT.getFont(aBold, aItalic));
+		RenderingUtils.drawText(pGraphics, textX, textY, pString, CANVAS_FONT.getFont(aBold, aItalic));
 		
 		if(aUnderlined && pString.trim().length() > 0)
 		{

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -108,16 +108,41 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 	
 	private void drawName(TypeNode pNode, Rectangle pBounds, int pSplitY, int pNameBoxHeight, GraphicsContext pGraphics)
 	{
-		String name = getNameText(pNode);
-		if( name.length() > 2 && name.startsWith(ITALIC_MARKUP) && name.endsWith(ITALIC_MARKUP) )
+		String name = getNameText(pNode).trim();
+		String[] nameByLine = name.split("\n");
+		int numLines = nameByLine.length;
+		
+		for( int i = 0; i < numLines; i++ )
 		{
-			ITALIC_NAME_VIEWER.draw(removeMarkup(name), pGraphics, 
-					new Rectangle(pBounds.x(), pSplitY, pBounds.width(), pNameBoxHeight));
-		}
-		else
-		{
-			NAME_VIEWER.draw(name, pGraphics, 
-					new Rectangle(pBounds.x(), pSplitY, pBounds.width(), pNameBoxHeight));
+			boolean italic = false;
+			String paddedName = "";
+			if( nameByLine[i].length() > 2 && nameByLine[i].startsWith(ITALIC_MARKUP) && nameByLine[i].endsWith(ITALIC_MARKUP) )
+			{
+				nameByLine[i] = removeMarkup(nameByLine[i]);
+				italic = true;
+			}
+			// We pad each line to maintain centering of entire name in the node. This allows us to render the name line by line.
+			for( int j = 0; j < numLines; j++ )
+			{
+				if( i == j )
+				{
+					paddedName += nameByLine[i];
+				}
+				else
+				{
+					paddedName += "\n";
+				}
+			}
+			if( italic )
+			{
+				ITALIC_NAME_VIEWER.draw(paddedName, pGraphics, 
+						new Rectangle(pBounds.x(), pSplitY, pBounds.width(), pNameBoxHeight));
+			}
+			else
+			{
+				NAME_VIEWER.draw(paddedName, pGraphics, 
+						new Rectangle(pBounds.x(), pSplitY, pBounds.width(), pNameBoxHeight));
+			}
 		}
 	}
 	

--- a/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
+++ b/src/org/jetuml/rendering/nodes/TypeNodeRenderer.java
@@ -148,7 +148,7 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 	
 	private static void drawAttribute(TypeNode pNode, Rectangle pBounds, int pSplitY, int pAttributeBoxHeight, GraphicsContext pGraphics)
 	{
-		String attributes = pNode.getAttributes();
+		String attributes = pNode.getAttributes().trim();
 		String[] attributesByLine = attributes.split("\n");
 		int lineSpacing = TOP_MARGIN;
 		
@@ -170,7 +170,7 @@ public class TypeNodeRenderer extends AbstractNodeRenderer
 	
 	private static void drawMethod(TypeNode pNode, Rectangle pBounds, int pSplitY, int pMethodBoxHeight, GraphicsContext pGraphics)
 	{
-		String methods = pNode.getMethods();
+		String methods = pNode.getMethods().trim();
 		String[] methodsByLine = methods.split("\n");
 		int lineSpacing = TOP_MARGIN;
 		

--- a/test/org/jetuml/layouttests/AbstractTestDiagramLayout.java
+++ b/test/org/jetuml/layouttests/AbstractTestDiagramLayout.java
@@ -20,6 +20,7 @@
  *******************************************************************************/
 package org.jetuml.layouttests;
 
+import static org.jetuml.rendering.FontMetrics.DEFAULT_FONT_NAME;
 import static org.jetuml.rendering.FontMetrics.DEFAULT_FONT_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +34,7 @@ import java.util.stream.Collectors;
 
 import org.jetuml.application.UserPreferences;
 import org.jetuml.application.UserPreferences.IntegerPreference;
+import org.jetuml.application.UserPreferences.StringPreference;
 import org.jetuml.diagram.Diagram;
 import org.jetuml.diagram.DiagramType;
 import org.jetuml.diagram.Edge;
@@ -55,11 +57,14 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public abstract class AbstractTestDiagramLayout
 {	
+	private static String userDefinedFontName;
 	private static int userDefinedFontSize;
 	
 	@BeforeAll
 	public static void setupClass()
 	{
+		userDefinedFontName = UserPreferences.instance().getString(UserPreferences.StringPreference.fontName);
+		UserPreferences.instance().setString(StringPreference.fontName, DEFAULT_FONT_NAME);
 		userDefinedFontSize = UserPreferences.instance().getInteger(UserPreferences.IntegerPreference.fontSize);
 		UserPreferences.instance().setInteger(IntegerPreference.fontSize, DEFAULT_FONT_SIZE);
 	}
@@ -67,6 +72,7 @@ public abstract class AbstractTestDiagramLayout
 	@AfterAll
 	public static void restorePreferences()
 	{
+		UserPreferences.instance().setString(StringPreference.fontName, userDefinedFontName);
 		UserPreferences.instance().setInteger(IntegerPreference.fontSize, userDefinedFontSize);
 	}
 	


### PR DESCRIPTION
- Fix unit tests to set default and restore user defined font.
- Allow italicizing abstract class names with stereotypes.