### PR TITLE
[#528] Minor Redesign of StringRenderer Class

### DIFF
--- a/src/org/jetuml/geom/Direction.java
+++ b/src/org/jetuml/geom/Direction.java
@@ -126,7 +126,7 @@ public final class Direction
 	 * 
 	 * @param pStart The start direction (exclusive)
 	 * @param pEnd The end direction (exclusive)
-	 * @return True if this direction represents an angle between pStart (inclusive) and pEnd (exclusive).
+	 * @return True if this direction represents an angle between pStart (exclusive) and pEnd (exclusive).
 	 * @pre pStart != null && pEnd != null && pStart != pEnd.
 	 */
 	public boolean isBetween( Direction pStart, Direction pEnd)

--- a/src/org/jetuml/geom/GeomUtils.java
+++ b/src/org/jetuml/geom/GeomUtils.java
@@ -100,17 +100,17 @@ public final class GeomUtils
 		Direction diagonalSW = diagonalNE.mirrored();
 		Direction diagonalNW = diagonalSE.mirrored();
 		
-		if( pDirection.isBetween(diagonalNE, diagonalSE))
+		if( pDirection.isBetween(diagonalNE, diagonalSE.rotatedBy(1)))
 		{
 			int offset = lengthOfOpposingSide(pDirection.asAngle() - Direction.EAST.asAngle(), pRectangle.width()/2);
 			return new Point(pRectangle.maxX(), pRectangle.center().y() + offset);
 		}
-		else if( pDirection.isBetween(diagonalSE, diagonalSW))
+		else if( pDirection.isBetween(diagonalSE, diagonalSW.rotatedBy(1)))
 		{
 			int offset = lengthOfOpposingSide(pDirection.asAngle() - Direction.SOUTH.asAngle(), pRectangle.height()/2);
 			return new Point(pRectangle.center().x() - offset, pRectangle.maxY());
 		}
-		else if( pDirection.isBetween(diagonalSW, diagonalNW))
+		else if( pDirection.isBetween(diagonalSW, diagonalNW.rotatedBy(1)))
 		{
 			int offset = lengthOfOpposingSide(pDirection.asAngle() - Direction.WEST.asAngle(), pRectangle.width()/2);
 			return new Point(pRectangle.x(), pRectangle.center().y() - offset);

--- a/src/org/jetuml/rendering/CanvasFont.java
+++ b/src/org/jetuml/rendering/CanvasFont.java
@@ -20,6 +20,7 @@
  *******************************************************************************/
 package org.jetuml.rendering;
 
+import org.jetuml.annotations.Singleton;
 import org.jetuml.application.UserPreferences;
 import org.jetuml.application.UserPreferences.IntegerPreference;
 import org.jetuml.application.UserPreferences.IntegerPreferenceChangeHandler;
@@ -32,19 +33,18 @@ import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 
 /**
- * A utility class for StringRenderer that is in sync with  
- * the user font size setting and manages font metrics calculations.
+ * A utility class for StringRenderer objects.
+ * CanvasFont is in sync with user font settings, and 
+ * it manages font metrics calculations through FontMetrics.
  */
+@Singleton
 public final class CanvasFont implements IntegerPreferenceChangeHandler, StringPreferenceChangeHandler
 {	
 	private Font aFont;
 	private Font aFontBold;
 	private Font aFontItalic;
 	private Font aFontBoldItalic;
-	private FontMetrics aFontMetrics;
-	private FontMetrics aFontBoldMetrics;
-	private FontMetrics aFontItalicMetrics;
-	private FontMetrics aFontBoldItalicMetrics;
+	private FontMetrics aFontMetrics = new FontMetrics();
 
 	/**
 	 * Initializes its attributes based on the user's preferences.
@@ -55,7 +55,6 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 		UserPreferences.instance().addIntegerPreferenceChangeHandler(this);
 		UserPreferences.instance().addStringPreferenceChangeHandler(this);
 	}
-	
 	
 	/**
 	 * @param pBold Whether the font is bold.
@@ -79,23 +78,6 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 		return aFont;
 	}
 
-	private FontMetrics getFontMetrics(boolean pBold, boolean pItalic)
-	{
-		if( pBold && pItalic )
-		{
-			return aFontBoldItalicMetrics;
-		}
-		else if( pBold )
-		{
-			return aFontBoldMetrics;
-		}
-		else if( pItalic )
-		{
-			return aFontItalicMetrics;
-		}
-		return aFontMetrics;
-	}
-
 	/**
 	 * Returns the dimension of a given string.
 	 * 
@@ -109,13 +91,12 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 	{
 		assert pString != null;
 		
-		return getFontMetrics(pBold, pItalic).getDimension(pString);
+		return aFontMetrics.getDimension(pString, getFont(pBold, pItalic));
 	}
 	
 	/**
 	 * Returns the distance between the top and bottom of a single lined text.
 	 * 
-	 * @param pString The string.
 	 * @param pBold Whether the text is in bold.
 	 * @param pItalic Whether the text is in italic.
 	 * @return The height of the string.
@@ -123,7 +104,7 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 	 */
 	public int getHeight(boolean pBold, boolean pItalic)
 	{
-		return getFontMetrics(pBold, pItalic).getHeight();
+		return aFontMetrics.getHeight(getFont(pBold, pItalic));
 	}
 	
 	/**
@@ -135,7 +116,7 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 	 */
 	public int getBaselineOffset(boolean pBold, boolean pItalic)
 	{
-		return getFontMetrics(pBold, pItalic).getBaselineOffset();
+		return aFontMetrics.getBaselineOffset(getFont(pBold, pItalic));
 	}
 
 	@Override
@@ -164,10 +145,6 @@ public final class CanvasFont implements IntegerPreferenceChangeHandler, StringP
 		aFontBold = Font.font(aFont.getFamily(), FontWeight.BOLD, aFont.getSize());
 		aFontItalic = Font.font(aFont.getFamily(), FontPosture.ITALIC, aFont.getSize());
 		aFontBoldItalic = Font.font(aFont.getFamily(), FontWeight.BOLD, FontPosture.ITALIC, aFont.getSize());
-		aFontMetrics = new FontMetrics(aFont);
-		aFontBoldMetrics = new FontMetrics(aFontBold);
-		aFontItalicMetrics = new FontMetrics(aFontItalic);
-		aFontBoldItalicMetrics = new FontMetrics(aFontBoldItalic);
 	}
 
 }

--- a/src/org/jetuml/rendering/FontMetrics.java
+++ b/src/org/jetuml/rendering/FontMetrics.java
@@ -52,35 +52,27 @@ public class FontMetrics
 	public static final String DEFAULT_FONT_NAME = "System";
 	public static final Font DEFAULT_FONT = Font.font(DEFAULT_FONT_NAME, DEFAULT_FONT_SIZE);
 	private static final String SINGLE_LINED_TEXT = "One";
-	private static final String TWO_LINED_TEXT = "One\nTwo";
-	private Text aTextNode;
-
-	/**
-	 * Creates a new FontMetrics object.
-	 * @param pFont The font to use.
-	 */
-
-	public FontMetrics(Font pFont)
-	{
-		assert pFont != null;
-		
-		aTextNode = new Text();
-		aTextNode.setFont(pFont);
-	}
+	private Text aTextNode = new Text();
 
 	/**
 	 * Returns the dimension of a given string.
 	 * For the fonts supported in JetUML, the dimension includes the leading space in the height.
-	 * However, this behavior is not consistent across all fonts.
+	 * However, it should be noted this behavior is not consistent across all fonts,
+	 * in the case additional fonts are to be supported in the future
 	 * 
 	 * @param pString The string to which the bounds pertain.
+	 * @param pFont the font of the text.
 	 * @return The dimension of the string
+	 * @pre pString != null
+	 * @pre pFont != null
 	 */
-	public Dimension getDimension(String pString)
+	public Dimension getDimension(String pString, Font pFont)
 	{
 		assert pString != null;
+		assert pFont != null;
 		
 		aTextNode.setText(pString);
+		aTextNode.setFont(pFont);
 		Bounds bounds = aTextNode.getLayoutBounds();
 		return new Dimension(GeomUtils.round(bounds.getWidth()), GeomUtils.round(bounds.getHeight()));
 	}
@@ -88,31 +80,35 @@ public class FontMetrics
 	/**
 	 * Returns the distance between the top and bottom of a single lined text.
 	 * Text#getLayoutBounds().getHeight() varies in its inclusion of the leading space depending on the font,
-	 * hence the subtraction approach was taken to ensure inclusion of the leading space.
+	 * but for the fonts that are currently supported, the leading space is included.
+	 * In the case additional fonts are supported in the future, this method will have to be adapted.
 	 * 
-	 * @param pString The string. 
+	 * @param pFont the font of the text.
 	 * @return The height of a single lined text.
-	 * @pre pString != null
+	 * @pre pFont != null
 	 */
-	public int getHeight()
+	public int getHeight(Font pFont)
 	{
-		aTextNode.setText(TWO_LINED_TEXT);
-		double twoLineHeight = aTextNode.getLayoutBounds().getHeight();
+		assert pFont != null;
+		
 		aTextNode.setText(SINGLE_LINED_TEXT);
-		double singleLineHeight = aTextNode.getLayoutBounds().getHeight();
-		return GeomUtils.round(twoLineHeight - singleLineHeight);
+		aTextNode.setFont(pFont);
+		return GeomUtils.round(aTextNode.getLayoutBounds().getHeight());
 	}
 	
 	/**
 	 * Returns the distance between the top and baseline of a single lined text.
 	 * 
-	 * @param pBold Whether the font is bold.
-	 * @param pItalic whether the font is italic.
+	 * @param pFont the font of the text.
 	 * @return the distance above the baseline for a single lined text.
+	 * @pre pFont != null
 	 */
-	public int getBaselineOffset()
+	public int getBaselineOffset(Font pFont)
 	{
+		assert pFont != null;
+		
 		aTextNode.setText(SINGLE_LINED_TEXT);
+		aTextNode.setFont(pFont);
 		return GeomUtils.round(aTextNode.getBaselineOffset());
 	}
 } 

--- a/test/org/jetuml/geom/TestGeomUtils.java
+++ b/test/org/jetuml/geom/TestGeomUtils.java
@@ -146,6 +146,30 @@ public class TestGeomUtils
 	}
 	
 	@Test
+	void testIntersectRectangle_NE_Corner()
+	{
+		assertEquals(new Point(60,0), GeomUtils.intersectRectangle(aRectangle, Direction.fromAngle(56)));
+	}
+	
+	@Test
+	void testIntersectRectangle_SE_Corner()
+	{
+		assertEquals(new Point(60,40), GeomUtils.intersectRectangle(aRectangle, Direction.fromAngle(124)));
+	}
+	
+	@Test
+	void testIntersectRectangle_SW_Corner()
+	{
+		assertEquals(new Point(0,40), GeomUtils.intersectRectangle(aRectangle, Direction.fromAngle(236)));
+	}
+	
+	@Test
+	void testIntersectRectangle_NW_Corner()
+	{
+		assertEquals(new Point(0,0), GeomUtils.intersectRectangle(aRectangle, Direction.fromAngle(304)));
+	}
+	
+	@Test
 	void testIntersectCircle_North()
 	{
 		assertEquals(new Point(10,0), GeomUtils.intersectCircle(aSquare, Direction.NORTH));

--- a/test/org/jetuml/rendering/TestFontMetrics.java
+++ b/test/org/jetuml/rendering/TestFontMetrics.java
@@ -30,21 +30,21 @@ import org.junit.jupiter.api.condition.OS;
 
 public class TestFontMetrics {
 
-	private static final FontMetrics aMetrics = new FontMetrics(DEFAULT_FONT);
+	private static final FontMetrics aMetrics = new FontMetrics();
 	
 	@Test
 	@EnabledOnOs(OS.WINDOWS)
 	public void testGetDimensions()
 	{
-		assertEquals(new Dimension(0, 16), aMetrics.getDimension(""));
-		assertEquals(new Dimension(95, 16), aMetrics.getDimension("Single-Line-String"));
-		assertEquals(new Dimension(31, 48), aMetrics.getDimension("Multi\nLine\nString"));
+		assertEquals(new Dimension(0, 16), aMetrics.getDimension("", DEFAULT_FONT));
+		assertEquals(new Dimension(95, 16), aMetrics.getDimension("Single-Line-String", DEFAULT_FONT));
+		assertEquals(new Dimension(31, 48), aMetrics.getDimension("Multi\nLine\nString", DEFAULT_FONT));
 	}
 	
 	@Test 
 	@EnabledOnOs(OS.WINDOWS)
 	public void testGetHeight_TwoLineString()
 	{
-		assertEquals(16, aMetrics.getHeight());	
+		assertEquals(16, aMetrics.getHeight(DEFAULT_FONT));	
 	}
 }


### PR DESCRIPTION
I moved the dependency on `Font` from the constructor of `FontMetrics` to its methods, which reduced the number of `FontMetrics` variables in `CanvasFont`.