### PR TITLE
[#553] Scroll Bar Fix

### DIFF
--- a/src/org/jetuml/gui/PropertySheet.java
+++ b/src/org/jetuml/gui/PropertySheet.java
@@ -43,7 +43,6 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.control.ScrollPane.ScrollBarPolicy;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;

--- a/src/org/jetuml/gui/PropertySheet.java
+++ b/src/org/jetuml/gui/PropertySheet.java
@@ -43,6 +43,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
+import javafx.scene.control.ScrollPane.ScrollBarPolicy;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
@@ -192,7 +193,11 @@ public class PropertySheet extends GridPane
 		   aListener.propertyChanged();
 		});
 		
-		return new ScrollPane(textArea);
+		// Necessary to fix scroll bar problem. See issue #553.
+		ScrollPane sp = new ScrollPane(textArea);
+		sp.setFitToHeight(true);
+		sp.setFitToWidth(true);
+		return sp;
 	}
 	
 	/*


### PR DESCRIPTION
Scroll bars unnecessarily appear on the `TextArea` in the properties dialog of a node, if the user has their monitor display setting at a higher scale (greater than 100% on Windows).

The scroll bars appear because the dimension of the `TextArea` is larger than the space that is allocated by its `ScrollPane` parent. This mismatch seems to occur due to JavaFX not considering the effect scale has on dimension computation for different components.