### PR TITLE
[#559] Create Separate Landing Page for Website and GitHub Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,26 @@ A lightweight desktop application for interactively creating and editing diagram
 ## Endorsements
 
 > I do a fair bit of modeling with some commercial tools which can be quite heavyweight. Whenever I need to quickly sketch out a design before writing code I prefer JetUML in most cases.
->
-> — Randall Hudson, Mitre Corporation
+  — Randall Hudson, Mitre Corporation
+
+## Download
+
+JetUML is available both as a self-contained application and as a Java archive file under the terms of the [GNU General Public License v3](https://www.gnu.org/licenses/gpl.html). Download the application from the [latest release](https://github.com/prmr/JetUML/releases) page and if necessary see the [installation guide](docs/install.md). Please consider supporting the project by starring this repo and by [writing an endorsement](mailto:jetuml@cs.mcgill.ca).
 
 ## Privacy Policy
 
 JetUML does not collect any information, personal or otherwise. The application only accesses the network to open web pages via the commands in the Help menu.
+
+
+
+## Documentation
+
+* [Installation Guide](docs/install.md)
+* [User Guide](https://www.jetuml.org/docs/user-guide-topics.html)
+* [JetUML File Format](docs/schemas.md)
+* [Contributing Guidelines](docs/CONTRIBUTING.md)
+* [Guide for JetUML Developers](docs/developers.md)
+* [Architecture Description](/docs/architecture.md)
 
 ## JetUML in the Literature
 
@@ -28,3 +42,4 @@ JetUML does not collect any information, personal or otherwise. The application 
 * D. Marmsoler and A. Petrovska. **Detecting Architectural Erosion using Runtime Verification**. In Proceedings of the 12th Interaction and Concurrency Experience Workshop, 2019. *Applies a verification method to JetUML*. [(pdf)](https://www.researchgate.net/publication/333748317_Detecting_Architectural_Erosion_using_Runtime_Verification/download)
 * Q. Wang, Y. Brun, A. Orso. **Behavioral Execution Comparison: Are Tests Representative of Field Behavior?**. In Proceedings of the 10th IEEE International Conference on Software Testing, Verification, and Validation, 2017. *Analyzes JetUML's test suite*. [(pdf)](https://people.cs.umass.edu/~brun/pubs/pubs/Wang17icst.pdf)
 * M.P. Robillard. **Sustainable Software Design**. In Proceedings of the 24th ACM SIGSOFT International Symposium on the Foundations of Software Engineering, 2016. *Discusses some of JetUML's design decisions*. [(pdf)](https://www.cs.mcgill.ca/~martin/papers/fse2016.pdf)
+

--- a/index.md
+++ b/index.md
@@ -1,0 +1,30 @@
+# JetUML
+
+[![GitHub release](https://img.shields.io/github/release/prmr/JetUML.svg)](https://gitHub.com/prmr/JetUML/releases/)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+![GitHub all releases](https://img.shields.io/github/downloads/prmr/JetUML/total)
+![GitHub Repo stars](https://img.shields.io/github/stars/prmr/JetUML?color=Green)
+![GitHub contributors](https://img.shields.io/github/contributors/prmr/JetUML)
+
+
+A lightweight desktop application for interactively creating and editing diagrams in the Unified Modeling Language. JetUML supports the sketching of software design ideas with a minimum of fuss. Diagrams can be saved in JSON, exported to popular image formats, and copied to the system clipboard for integration with other tools. Supports class diagrams, sequence diagrams, state diagrams, object diagrams, and use case diagrams. 
+
+![JetUML Class Diagram](docs/banner.png)
+
+## Endorsements
+
+> I do a fair bit of modeling with some commercial tools which can be quite heavyweight. Whenever I need to quickly sketch out a design before writing code I prefer JetUML in most cases.
+>
+> — Randall Hudson, Mitre Corporation
+
+## Privacy Policy
+
+JetUML does not collect any information, personal or otherwise. The application only accesses the network to open web pages via the commands in the Help menu.
+
+## JetUML in the Literature
+
+* M.P. Robillard and K. Kutschera. **Lessons Learned in Migrating from Swing to JavaFX**. IEEE Software,  37 (3), 2020. *Reports on the experience of migrating the GUI to JavaFX*. [(pdf)](https://www.cs.mcgill.ca/~martin/papers/software2019.pdf)
+* F. Pfahler, R. Minelli, C. Nagy, M. Lanza. **Visualizing Evolving Software Cities**. In Proceedings of the 8th Working Conference on Software Visualization, 2020. *Discusses the evolution of the JetUML code base*. [(pdf)](https://www.inf.usi.ch/lanza/Downloads/Pfah2020a.pdf)
+* D. Marmsoler and A. Petrovska. **Detecting Architectural Erosion using Runtime Verification**. In Proceedings of the 12th Interaction and Concurrency Experience Workshop, 2019. *Applies a verification method to JetUML*. [(pdf)](https://www.researchgate.net/publication/333748317_Detecting_Architectural_Erosion_using_Runtime_Verification/download)
+* Q. Wang, Y. Brun, A. Orso. **Behavioral Execution Comparison: Are Tests Representative of Field Behavior?**. In Proceedings of the 10th IEEE International Conference on Software Testing, Verification, and Validation, 2017. *Analyzes JetUML's test suite*. [(pdf)](https://people.cs.umass.edu/~brun/pubs/pubs/Wang17icst.pdf)
+* M.P. Robillard. **Sustainable Software Design**. In Proceedings of the 24th ACM SIGSOFT International Symposium on the Foundations of Software Engineering, 2016. *Discusses some of JetUML's design decisions*. [(pdf)](https://www.cs.mcgill.ca/~martin/papers/fse2016.pdf)


### PR DESCRIPTION
This change creates a separate landing page for the website and the GitHub repo.