### PR TITLE
[#577] Use native Mac menu bar

### DIFF
--- a/src/org/jetuml/gui/EditorFrame.java
+++ b/src/org/jetuml/gui/EditorFrame.java
@@ -103,6 +103,7 @@ public class EditorFrame extends BorderPane implements BooleanPreferenceChangeHa
 		aRecentFiles.deserialize(Preferences.userNodeForPackage(JetUML.class).get("recent", "").trim());
 
 		MenuBar menuBar = new MenuBar();
+        moveMenuBarToMacNativeMenuBar(menuBar);
 		setTop(menuBar);
 		
 		TabPane tabPane = new TabPane();
@@ -146,6 +147,19 @@ public class EditorFrame extends BorderPane implements BooleanPreferenceChangeHa
 		}
 		return validFormats.toArray(new String[validFormats.size()]);
 	}
+
+    /*
+     * Moves the menu bar to the system menu bar on macOS systems.
+     * A macOS system is indicated by the string "Mac OS X" in
+     * System property `os.name`.
+     */
+    private void moveMenuBarToMacNativeMenuBar(MenuBar pMenuBar)
+    {
+        if (System.getProperty("os.name").equals("Mac OS X"))
+        {
+            pMenuBar.setUseSystemMenuBar(true);
+        }
+    }
 	
 	/*
 	 * Traverses all menu items up to the second level (top level


### PR DESCRIPTION
This adds support for the mac menubar.
See picture. Shot in macOS 15.7.1.
<img width="870" height="218" alt="Screenshot 2025-10-28 at 13 55 08" src="https://github.com/user-attachments/assets/1c10bc5b-a346-4945-a3a0-731aa05f7517" />